### PR TITLE
merged the 2 projects' entities and databases into the new project

### DIFF
--- a/Source/ArtAttack.Tests/Game_Repository_Tests.cs
+++ b/Source/ArtAttack.Tests/Game_Repository_Tests.cs
@@ -76,7 +76,7 @@ namespace Steampunks.Tests
         [Test]
         public async Task UpdateGameAsync_ValidGame_UpdatesGame()
         {
-            var game = new Game("Test Game", 10.0f, "RPG", "Description");
+            var game = new Game("Test Game", 10.0f, "RPG", "GameDescription");
             game.SetGameId(1);
             mockDatabaseConnector.Setup(x => x.GetNewConnection())
                 .Returns(new DatabaseConnector().GetNewConnection());

--- a/Source/ArtAttack.Tests/Game_Service_Tests.cs
+++ b/Source/ArtAttack.Tests/Game_Service_Tests.cs
@@ -35,7 +35,7 @@ namespace Steampunks_Tests
             var result = await service.GetAllGamesAsync();
 
             Assert.That(result.Count, Is.EqualTo(2));
-            Assert.That(result[0].Title, Is.EqualTo("Test Game1"));
+            Assert.That(result[0].GameTitle, Is.EqualTo("Test Game1"));
             mockRepository.Verify(r => r.GetGamesAsync(), Times.Once);
         }
 
@@ -48,7 +48,7 @@ namespace Steampunks_Tests
             var result = await service.GetGameByIdAsync(42);
 
             Assert.IsNotNull(result);
-            Assert.That(result.Title, Is.EqualTo("Test Game1"));
+            Assert.That(result.GameTitle, Is.EqualTo("Test Game1"));
             mockRepository.Verify(r => r.GetGameByIdAsync(42), Times.Once);
         }
 

--- a/Source/ArtAttack.Tests/InventoryTests/InventoryServiceTests.cs
+++ b/Source/ArtAttack.Tests/InventoryTests/InventoryServiceTests.cs
@@ -237,7 +237,7 @@ namespace Steampunks.Tests.InventoryTests
             var availableGames = service.GetAvailableGames(items);
 
             // Assert: One assert checking that the first game's title is the special "All Games" option.
-            Assert.AreEqual("All Games", availableGames[0].Title);
+            Assert.AreEqual("All Games", availableGames[0].GameTitle);
         }
 
         // 10. GetUserFilteredInventoryAsync tests

--- a/Source/ArtAttack.Tests/MarketplaceTests/MarketplaceServiceTests.cs
+++ b/Source/ArtAttack.Tests/MarketplaceTests/MarketplaceServiceTests.cs
@@ -67,7 +67,7 @@ namespace Steampunks_Tests.MarketplaceTests
         [Test]
         public async Task GetAllListingsAsync_ReturnsItemList()
         {
-            var game = new Game("Test Game", 9.99f, "RPG", "Game Description");
+            var game = new Game("Test Game", 9.99f, "RPG", "Game GameDescription");
             game.SetGameId(101);
             var items = new List<Item> {
                 new Item("New Item1", game, 5.99f, "Item Desc"),
@@ -88,7 +88,7 @@ namespace Steampunks_Tests.MarketplaceTests
         [Test]
         public async Task GetListingsByGameAsync_ReturnsListings()
         {
-            var game = new Game("Test Game", 9.99f, "RPG", "Game Description");
+            var game = new Game("Test Game", 9.99f, "RPG", "Game GameDescription");
             game.SetGameId(101);
             var listings = new List<Item> { new Item("New Item", game, 5.99f, "Item Desc") };
             mockRepository.Setup(r => r.GetListedItemsByGameAsync(game)).ReturnsAsync(listings);
@@ -100,7 +100,7 @@ namespace Steampunks_Tests.MarketplaceTests
         [Test]
         public void AddListingAsync_NullGame_ThrowsArgumentNullException()
         {
-            var game = new Game("Test Game", 9.99f, "RPG", "Game Description");
+            var game = new Game("Test Game", 9.99f, "RPG", "Game GameDescription");
             game.SetGameId(101);
             Assert.ThrowsAsync<ArgumentNullException>(() => service.AddListingAsync(null, new Item("New Item", game, 5.99f, "Item Desc")));
         }
@@ -108,14 +108,14 @@ namespace Steampunks_Tests.MarketplaceTests
         [Test]
         public void AddListingAsync_NullItem_ThrowsArgumentNullException()
         {
-            var game = new Game("Test Game", 9.99f, "RPG", "Game Description");
+            var game = new Game("Test Game", 9.99f, "RPG", "Game GameDescription");
             Assert.ThrowsAsync<ArgumentNullException>(() => service.AddListingAsync(game, null));
         }
 
         [Test]
         public async Task AddListingAsync_ValidInputs_CallsRepository()
         {
-            var game = new Game("Test Game", 9.99f, "RPG", "Game Description");
+            var game = new Game("Test Game", 9.99f, "RPG", "Game GameDescription");
             game.SetGameId(101);
             var item = new Item("New Item", game, 5.99f, "Item Desc") { IsListed = false };
             mockRepository.Setup(r => r.MakeItemListableAsync(game, item)).Returns(Task.CompletedTask);
@@ -127,7 +127,7 @@ namespace Steampunks_Tests.MarketplaceTests
         [Test]
         public void RemoveListingAsync_NullGame_ThrowsArgumentNullException()
         {
-            var game = new Game("Test Game", 9.99f, "RPG", "Game Description");
+            var game = new Game("Test Game", 9.99f, "RPG", "Game GameDescription");
             var item = new Item("New Item", game, 5.99f, "Item Desc");
             Assert.ThrowsAsync<ArgumentNullException>(() => service.RemoveListingAsync(null, item));
         }
@@ -135,14 +135,14 @@ namespace Steampunks_Tests.MarketplaceTests
         [Test]
         public void RemoveListingAsync_NullItem_ThrowsArgumentNullException()
         {
-            var game = new Game("Test Game", 9.99f, "RPG", "Game Description");
+            var game = new Game("Test Game", 9.99f, "RPG", "Game GameDescription");
             Assert.ThrowsAsync<ArgumentNullException>(() => service.RemoveListingAsync(game, null));
         }
 
         [Test]
         public async Task RemoveListingAsync_Valid_CallsRepository()
         {
-            var game = new Game("Test Game", 9.99f, "RPG", "Game Description");
+            var game = new Game("Test Game", 9.99f, "RPG", "Game GameDescription");
             game.SetGameId(101);
             var item = new Item("New Item", game, 5.99f, "Item Desc");
             mockRepository.Setup(r => r.MakeItemListableAsync(game, item)).Returns(Task.CompletedTask);
@@ -154,7 +154,7 @@ namespace Steampunks_Tests.MarketplaceTests
         [Test]
         public void UpdateListingAsync_NullGame_ThrowsArgumentNullException()
         {
-            var game = new Game("Test Game", 9.99f, "RPG", "Game Description");
+            var game = new Game("Test Game", 9.99f, "RPG", "Game GameDescription");
             game.SetGameId(101);
             Assert.ThrowsAsync<ArgumentNullException>(() => service.UpdateListingAsync(null, new Item("New Item", game, 5.99f, "Item Desc")));
         }
@@ -162,14 +162,14 @@ namespace Steampunks_Tests.MarketplaceTests
         [Test]
         public void UpdateListingAsync_NullItem_ThrowsArgumentNullException()
         {
-            var game = new Game("Test Game", 9.99f, "RPG", "Game Description");
+            var game = new Game("Test Game", 9.99f, "RPG", "Game GameDescription");
             Assert.ThrowsAsync<ArgumentNullException>(() => service.UpdateListingAsync(game, null));
         }
 
         [Test]
         public async Task UpdateListingAsync_Valid_CallsRepository()
         {
-            var game = new Game("Test Game", 9.99f, "RPG", "Game Description");
+            var game = new Game("Test Game", 9.99f, "RPG", "Game GameDescription");
             game.SetGameId(101);
             var item = new Item("New Item", game, 5.99f, "Item Desc");
             mockRepository.Setup(r => r.UpdateItemPriceAsync(game, item)).Returns(Task.CompletedTask);
@@ -187,7 +187,7 @@ namespace Steampunks_Tests.MarketplaceTests
         [Test]
         public void BuyItemAsync_UnlistedItem_ThrowsInvalidOperationException()
         {
-            var game = new Game("Test Game", 9.99f, "RPG", "Game Description");
+            var game = new Game("Test Game", 9.99f, "RPG", "Game GameDescription");
             game.SetGameId(101);
             var item = new Item("New Item", game, 5.99f, "Item Desc") { IsListed = false };
             Assert.ThrowsAsync<InvalidOperationException>(() => service.BuyItemAsync(item));
@@ -196,7 +196,7 @@ namespace Steampunks_Tests.MarketplaceTests
         [Test]
         public async Task BuyItemAsync_Valid_ReturnsTrue()
         {
-            var game = new Game("Test Game", 9.99f, "RPG", "Game Description");
+            var game = new Game("Test Game", 9.99f, "RPG", "Game GameDescription");
             game.SetGameId(101);
             var item = new Item("New Item", game, 5.99f, "Item Desc") { IsListed = true };
             mockRepository.Setup(r => r.BuyItemAsync(item, testUser)).ReturnsAsync(true);

--- a/Source/ArtAttack.Tests/TradeTests/TradeRepositoryTests.cs
+++ b/Source/ArtAttack.Tests/TradeTests/TradeRepositoryTests.cs
@@ -32,7 +32,7 @@ namespace Steampunks.Tests.Trade
                 new ItemTrade(
                     new User("sourceUser"),
                     new User("destUser"),
-                    new Game("Test Game", 10.0f, "Action", "Description"),
+                    new Game("Test Game", 10.0f, "Action", "GameDescription"),
                     "Test trade")
             };
 
@@ -57,7 +57,7 @@ namespace Steampunks.Tests.Trade
                 new ItemTrade(
                     new User("sourceUser"),
                     new User("destUser"),
-                    new Game("Test Game", 10.0f, "Action", "Description"),
+                    new Game("Test Game", 10.0f, "Action", "GameDescription"),
                     "Test trade")
             };
 
@@ -78,7 +78,7 @@ namespace Steampunks.Tests.Trade
             var trade = new ItemTrade(
                 new User("sourceUser"),
                 new User("destUser"),
-                new Game("Test Game", 10.0f, "Action", "Description"),
+                new Game("Test Game", 10.0f, "Action", "GameDescription"),
                 "Test trade");
             trade.SetTradeId(1);
             trade.AcceptBySourceUser();

--- a/Source/ArtAttack.Tests/TradeTests/TradeServiceTests.cs
+++ b/Source/ArtAttack.Tests/TradeTests/TradeServiceTests.cs
@@ -201,7 +201,7 @@ namespace Steampunks.Tests.Trade
             var trade = new ItemTrade(
                 new User("sourceUser"),
                 new User("destUser"),
-                new Game("Test Game", 10.0f, "Action", "Description"),
+                new Game("Test Game", 10.0f, "Action", "GameDescription"),
                 "Test trade");
             trade.SetTradeId(1);
             trade.AcceptBySourceUser();

--- a/Source/ArtAttack.Tests/UserTests/UserRepositoryTests.cs
+++ b/Source/ArtAttack.Tests/UserTests/UserRepositoryTests.cs
@@ -47,7 +47,7 @@ namespace Steampunks.Tests
             {
                 await connection.OpenAsync();
 
-                using var cmd = new SqlCommand("DELETE FROM Users WHERE Username = '!@#Special_User_测试_🚀'", connection);
+                using var cmd = new SqlCommand("DELETE FROM Users WHERE UserName = '!@#Special_User_测试_🚀'", connection);
                 await cmd.ExecuteNonQueryAsync();
             }
             finally
@@ -86,11 +86,11 @@ namespace Steampunks.Tests
             try
             {
                 var insertCommand = new SqlCommand(
-                    "INSERT INTO Users (Username, WalletBalance, PointBalance, IsDeveloper) " +
+                    "INSERT INTO Users (UserName, WalletBalance, PointBalance, IsDeveloper) " +
                     "OUTPUT INSERTED.UserId " +
-                    "VALUES (@Username, 0, 0, 0)",
+                    "VALUES (@UserName, 0, 0, 0)",
                     connection);
-                insertCommand.Parameters.AddWithValue("@Username", specialUser.Username);
+                insertCommand.Parameters.AddWithValue("@UserName", specialUser.UserName);
 
                 // await insertCommand.ExecuteNonQueryAsync();
                 var insertedId = (int)await insertCommand.ExecuteScalarAsync();
@@ -104,7 +104,7 @@ namespace Steampunks.Tests
             var fetched = await userRepository.GetUserByIdAsync(specialUser.UserId);
 
             Assert.That(fetched, Is.Not.Null);
-            Assert.That(fetched.Username, Does.Contain("Special"));
+            Assert.That(fetched.UserName, Does.Contain("Special"));
         }
 
     }

--- a/Source/ArtAttack.Tests/UserTests/UserServiceTests.cs
+++ b/Source/ArtAttack.Tests/UserTests/UserServiceTests.cs
@@ -68,7 +68,7 @@ public class UserServiceTests
 
         // Assert
         Assert.IsNotNull(result);
-        Assert.AreEqual("TestUser", result?.Username);
+        Assert.AreEqual("TestUser", result?.UserName);
         Assert.AreEqual(1, result?.UserId);
         Assert.AreEqual(150.5f, result?.WalletBalance);
         Assert.AreEqual(75.25f, result?.PointBalance);

--- a/Source/ArtAttack/DataLink/DatabaseConnector.cs
+++ b/Source/ArtAttack/DataLink/DatabaseConnector.cs
@@ -154,17 +154,17 @@ namespace Steampunks.DataLink
                     {
                         // Add the game first
                         const string gameQuery = @"
-                            INSERT INTO Games (Title, Price, Genre, Description, Status)
-                            VALUES (@Title, @Price, @Genre, @Description, 'Available');
+                            INSERT INTO Games (GameTitle, Price, Genre, GameDescription, Status)
+                            VALUES (@GameTitle, @Price, @Genre, @GameDescription, 'Available');
                             SELECT SCOPE_IDENTITY();";
 
                         int gameId;
                         using (var command = new SqlCommand(gameQuery, this.GetConnection(), transaction))
                         {
-                            command.Parameters.AddWithValue("@Title", gameTitle);
+                            command.Parameters.AddWithValue("@GameTitle", gameTitle);
                             command.Parameters.AddWithValue("@Price", gamePrice);
                             command.Parameters.AddWithValue("@Genre", genre);
-                            command.Parameters.AddWithValue("@Description", description);
+                            command.Parameters.AddWithValue("@GameDescription", description);
                             gameId = Convert.ToInt32(command.ExecuteScalar());
                         }
 
@@ -174,8 +174,8 @@ namespace Steampunks.DataLink
 
                         // Add each item
                         const string itemQuery = @"
-                            INSERT INTO Items (ItemName, GameId, Price, Description, IsListed)
-                            VALUES (@ItemName, @GameId, @Price, @Description, 0);";
+                            INSERT INTO Items (ItemName, GameId, Price, GameDescription, IsListed)
+                            VALUES (@ItemName, @GameId, @Price, @GameDescription, 0);";
 
                         foreach (var item in itemsToBeAdded)
                         {
@@ -184,7 +184,7 @@ namespace Steampunks.DataLink
                                 command.Parameters.AddWithValue("@ItemName", item.Name);
                                 command.Parameters.AddWithValue("@GameId", gameId);
                                 command.Parameters.AddWithValue("@Price", item.Price);
-                                command.Parameters.AddWithValue("@Description", item.Description);
+                                command.Parameters.AddWithValue("@GameDescription", item.Description);
                                 command.ExecuteNonQuery();
                             }
                         }
@@ -229,7 +229,7 @@ namespace Steampunks.DataLink
         public List<User> GetAllUsers()
         {
             var users = new List<User>();
-            using (var command = new SqlCommand("SELECT UserId, Username FROM Users", this.GetConnection()))
+            using (var command = new SqlCommand("SELECT UserId, UserName FROM Users", this.GetConnection()))
             {
                 try
                 {
@@ -238,7 +238,7 @@ namespace Steampunks.DataLink
                     {
                         while (reader.Read())
                         {
-                            var user = new User(reader.GetString(reader.GetOrdinal("Username")));
+                            var user = new User(reader.GetString(reader.GetOrdinal("UserName")));
                             user.SetUserId(reader.GetInt32(reader.GetOrdinal("UserId")));
                             users.Add(user);
                         }
@@ -268,7 +268,7 @@ namespace Steampunks.DataLink
         public async Task<List<User>> GetAllUsersAsync()
         {
             var users = new List<User>();
-            using (var command = new SqlCommand("SELECT UserId, Username FROM Users", this.GetConnection()))
+            using (var command = new SqlCommand("SELECT UserId, UserName FROM Users", this.GetConnection()))
             {
                 try
                 {
@@ -277,7 +277,7 @@ namespace Steampunks.DataLink
                     {
                         while (reader.Read())
                         {
-                            var user = new User(reader.GetString(reader.GetOrdinal("Username")));
+                            var user = new User(reader.GetString(reader.GetOrdinal("UserName")));
                             user.SetUserId(reader.GetInt32(reader.GetOrdinal("UserId")));
                             users.Add(user);
                         }
@@ -306,7 +306,7 @@ namespace Steampunks.DataLink
         /// <returns> Current user. </returns>
         public User? GetCurrentUser()
         {
-            using (var command = new SqlCommand("SELECT TOP 1 UserId, Username FROM Users", this.GetConnection()))
+            using (var command = new SqlCommand("SELECT TOP 1 UserId, UserName FROM Users", this.GetConnection()))
             {
                 try
                 {
@@ -315,7 +315,7 @@ namespace Steampunks.DataLink
                     {
                         if (reader.Read())
                         {
-                            var user = new User(reader.GetString(reader.GetOrdinal("Username")));
+                            var user = new User(reader.GetString(reader.GetOrdinal("UserName")));
                             user.SetUserId(reader.GetInt32(reader.GetOrdinal("UserId")));
                             return user;
                         }
@@ -342,7 +342,7 @@ namespace Steampunks.DataLink
                 "TestUser3",
             };
 
-            using (var command = new SqlCommand(@" INSERT INTO Users (Username, WalletBalance, PointBalance, IsDeveloper) VALUES (@Username, 1000, 100, 0)", this.GetConnection()))
+            using (var command = new SqlCommand(@" INSERT INTO Users (UserName, WalletBalance, PointBalance, IsDeveloper) VALUES (@UserName, 1000, 100, 0)", this.GetConnection()))
             {
                 try
                 {
@@ -350,7 +350,7 @@ namespace Steampunks.DataLink
                     foreach (var username in testUsers)
                     {
                         command.Parameters.Clear();
-                        command.Parameters.AddWithValue("@Username", username);
+                        command.Parameters.AddWithValue("@UserName", username);
                         command.ExecuteNonQuery();
                     }
                 }
@@ -371,17 +371,17 @@ namespace Steampunks.DataLink
             try
             {
                 // Get the game folder name based on the game title
-                string gameFolder = item.Game.Title.ToLower() switch
+                string gameFolder = item.Game.GameTitle.ToLower() switch
                 {
                     "counter-strike 2" => "cs2",
                     "dota 2" => "dota2",
                     "team fortress 2" => "tf2",
-                    _ => item.Game.Title.ToLower().Replace(" ", string.Empty).Replace(":", string.Empty)
+                    _ => item.Game.GameTitle.ToLower().Replace(" ", string.Empty).Replace(":", string.Empty)
                 };
 
                 // Return a path to the image based on the ItemId
                 var path = $"ms-appx:///Assets/img/games/{gameFolder}/{item.ItemId}.png";
-                System.Diagnostics.Debug.WriteLine($"Generated image path for item {item.ItemId} ({item.ItemName}) from {item.Game.Title}: {path}");
+                System.Diagnostics.Debug.WriteLine($"Generated image path for item {item.ItemId} ({item.ItemName}) from {item.Game.GameTitle}: {path}");
                 return path;
             }
             catch (Exception getItemImagePathException)

--- a/Source/ArtAttack/DataLink/Scripts/InitializeDatabase.sql
+++ b/Source/ArtAttack/DataLink/Scripts/InitializeDatabase.sql
@@ -238,7 +238,7 @@ BEGIN
     DBCC CHECKIDENT ('Items', RESEED, 0);
     DBCC CHECKIDENT ('Games', RESEED, 0);
     DBCC CHECKIDENT ('Users', RESEED, 0);
-    GO
+    
 
     -- Insert test users
     INSERT INTO Users (Username, WalletBalance, PointBalance, IsDeveloper)
@@ -246,7 +246,7 @@ BEGIN
     ('TestUser1', 1000, 100, 0),
     ('TestUser2', 1000, 100, 0),
     ('TestUser3', 1000, 100, 0);
-    GO
+    
 
     -- Insert games
     INSERT INTO Games (Title, Price, Genre, Description, Status)
@@ -254,7 +254,7 @@ BEGIN
     ('Counter-Strike 2', 0.00, 'FPS', 'The latest version of Counter-Strike', 'Available'),
     ('Dota 2', 0.00, 'MOBA', 'A competitive multiplayer game', 'Available'),
     ('Team Fortress 2', 0.00, 'FPS', 'A team-based multiplayer game', 'Available');
-    GO
+    
 
     -- Insert items
     INSERT INTO Items (ItemName, CorrespondingGameId, Price, Description, IsListed)
@@ -279,7 +279,7 @@ BEGIN
     ('Earbuds', 3, 400.00, 'A classic TF2 cosmetic item', 0),
     ('Unusual Burning Flames Team Captain', 3, 3000.00, 'A combination of two rare items', 0),
     ('Unusual Scorching Flames Team Captain', 3, 2500.00, 'Another rare variant of the Team Captain', 0);
-    GO
+    
 
     -- Insert mock items into UserInventory
     INSERT INTO UserInventory (UserId, ItemId, GameId, AcquiredDate)
@@ -305,4 +305,3 @@ BEGIN
     (3, 4, 1, GETDATE()),   -- Karambit | Fade
     (3, 5, 1, GETDATE());   -- M4A1-S | Knight
 END
-GO 

--- a/Source/ArtAttack/Domain/Entities/Game.cs
+++ b/Source/ArtAttack/Domain/Entities/Game.cs
@@ -56,10 +56,10 @@ namespace Steampunks.Domain.Entities
         /// <param name="description">The description of the game.</param>
         public Game(string title, float price, string genre, string description)
         {
-            this.Title = title;
+            this.GameTitle = title;
             this.Price = price;
             this.Genre = genre;
-            this.Description = description;
+            this.GameDescription = description;
             this.GameReviews = new List<Review>();
             this.Status = DefaultStatus;
         }
@@ -69,9 +69,9 @@ namespace Steampunks.Domain.Entities
         /// </summary>
         private Game()
         {
-            this.Title = string.Empty;
+            this.GameTitle = string.Empty;
             this.Genre = string.Empty;
-            this.Description = string.Empty;
+            this.GameDescription = string.Empty;
             this.GameReviews = new List<Review>();
         }
 
@@ -93,7 +93,7 @@ namespace Steampunks.Domain.Entities
         /// <summary>
         /// Gets the title of the game.
         /// </summary>
-        public string Title { get; private set; }
+        public string GameTitle { get; private set; }
 
         /// <summary>
         /// Gets the price of the game.
@@ -108,7 +108,7 @@ namespace Steampunks.Domain.Entities
         /// <summary>
         /// Gets the description of the game.
         /// </summary>
-        public string Description { get; private set; }
+        public string GameDescription { get; private set; }
 
         /// <summary>
         /// Gets the list of reviews associated with the game.
@@ -145,7 +145,7 @@ namespace Steampunks.Domain.Entities
         /// <returns>The title of the game.</returns>
         public string GetTitle()
         {
-            return this.Title;
+            return this.GameTitle;
         }
 
         /// <summary>
@@ -154,7 +154,7 @@ namespace Steampunks.Domain.Entities
         /// <param name="title">The title of the game.</param>
         public void SetTitle(string title)
         {
-            this.Title = title;
+            this.GameTitle = title;
         }
 
         /// <summary>
@@ -199,7 +199,7 @@ namespace Steampunks.Domain.Entities
         /// <returns>The description of the game.</returns>
         public string GetDescription()
         {
-            return this.Description;
+            return this.GameDescription;
         }
 
         /// <summary>
@@ -208,7 +208,7 @@ namespace Steampunks.Domain.Entities
         /// <param name="description">The description of the game.</param>
         public void SetDescription(string description)
         {
-            this.Description = description;
+            this.GameDescription = description;
         }
 
         /// <summary>
@@ -241,7 +241,7 @@ namespace Steampunks.Domain.Entities
         /// <inheritdoc/>
         public override string ToString()
         {
-            return this.Price > MinimumDisplayPrice ? $"{this.Title} (${this.Price:F2})" : this.Title;
+            return this.Price > MinimumDisplayPrice ? $"{this.GameTitle} (${this.Price:F2})" : this.GameTitle;
         }
     }
 }

--- a/Source/ArtAttack/Domain/Entities/Item.cs
+++ b/Source/ArtAttack/Domain/Entities/Item.cs
@@ -203,16 +203,16 @@ namespace Steampunks.Domain.Entities
         private string GetDefaultImagePath(string itemName)
         {
             // Get the game folder name based on the game title
-            string gameFolder = this.associatedGame.Title.ToLower() switch
+            string gameFolder = this.associatedGame.GameTitle.ToLower() switch
             {
                 GameTitleCounterStrike => GameFolderCounterStrike,
                 GameTitleDota => GameFolderDota,
                 GameTitleTeamFortress => GameFolderTeamFortress,
-                _ => this.associatedGame.Title.ToLower().Replace(" ", string.Empty).Replace(":", string.Empty)
+                _ => this.associatedGame.GameTitle.ToLower().Replace(" ", string.Empty).Replace(":", string.Empty)
             };
 
             var path = $"{ImageBasePath}{gameFolder}/{this.itemId}.png";
-            Debug.WriteLine($"Generated image path for item {this.itemId} ({itemName}) from {this.associatedGame.Title}: {path}");
+            Debug.WriteLine($"Generated image path for item {this.itemId} ({itemName}) from {this.associatedGame.GameTitle}: {path}");
             return path;
         }
     }

--- a/Source/ArtAttack/Domain/Entities/User.cs
+++ b/Source/ArtAttack/Domain/Entities/User.cs
@@ -20,7 +20,7 @@ namespace Steampunks.Domain.Entities
         /// <param name="username">The username of the user.</param>
         public User(string username)
         {
-            this.Username = username;
+            this.UserName = username;
             this.WalletBalance = InitialWalletBalance;
             this.PointBalance = InitialPointBalance;
             this.IsDeveloper = false;
@@ -41,7 +41,7 @@ namespace Steampunks.Domain.Entities
         /// <summary>
         /// Gets the username of the user.
         /// </summary>
-        public string Username { get; private set; }
+        public string UserName { get; private set; }
 
         /// <summary>
         /// Gets the wallet balance of the user.
@@ -73,7 +73,7 @@ namespace Steampunks.Domain.Entities
         /// <param name="username">The new username.</param>
         public void SetUsername(string username)
         {
-            this.Username = username;
+            this.UserName = username;
         }
 
         /// <summary>

--- a/Source/ArtAttack/Repository/Game/GameRepository.cs
+++ b/Source/ArtAttack/Repository/Game/GameRepository.cs
@@ -23,38 +23,38 @@ namespace Steampunks.Repository.GameRepo
         private const string GetAllGamesQuery = @"
     SELECT 
         GameId,
-        Title,
+        GameTitle,
         Price,
         Genre,
-        Description,
+        GameDescription,
         Status
     FROM Games
-    ORDER BY Title";
+    ORDER BY GameTitle";
 
         private const string GetGameByIdQuery = @"
     SELECT 
         GameId,
-        Title,
+        GameTitle,
         Price,
         Genre,
-        Description,
+        GameDescription,
         Status
     FROM Games
     WHERE GameId = @GameId";
 
         private const string UpdateGameQuery = @"
     UPDATE Games
-    SET Title = @Title,
+    SET GameTitle = @GameTitle,
         Price = @Price,
         Genre = @Genre,
-        Description = @Description
+        GameDescription = @GameDescription
     WHERE GameId = @GameId";
 
         private const string ColumnGameId = "GameId";
-        private const string ColumnTitle = "Title";
+        private const string ColumnTitle = "GameTitle";
         private const string ColumnPrice = "Price";
         private const string ColumnGenre = "Genre";
-        private const string ColumnDescription = "Description";
+        private const string ColumnDescription = "GameDescription";
         private const string ColumnStatus = "Status";
 
         /// <summary>
@@ -205,10 +205,10 @@ namespace Steampunks.Repository.GameRepo
                 using (var command = new SqlCommand(UpdateGameQuery, this.databaseConnector.GetConnection()))
                 {
                     command.Parameters.AddWithValue(ColumnGameId, game.GameId);
-                    command.Parameters.AddWithValue(ColumnTitle, game.Title);
+                    command.Parameters.AddWithValue(ColumnTitle, game.GameTitle);
                     command.Parameters.AddWithValue(ColumnPrice, game.Price);
                     command.Parameters.AddWithValue(ColumnGenre, game.Genre);
-                    command.Parameters.AddWithValue(ColumnDescription, game.Description);
+                    command.Parameters.AddWithValue(ColumnDescription, game.GameDescription);
 
                     await this.databaseConnector.OpenConnectionAsync();
                     int rowsAffected = await command.ExecuteNonQueryAsync();

--- a/Source/ArtAttack/Repository/Inventory/InventoryRepository.cs
+++ b/Source/ArtAttack/Repository/Inventory/InventoryRepository.cs
@@ -50,7 +50,7 @@ namespace Steampunks.Repository.Inventory
                     i.ItemId,
                     i.ItemName,
                     i.Price,
-                    i.Description,
+                    i.GameDescription,
                     i.IsListed
                 FROM Items i
                 JOIN UserInventory ui ON i.ItemId = ui.ItemId
@@ -77,7 +77,7 @@ namespace Steampunks.Repository.Inventory
                                 reader.GetString(reader.GetOrdinal("ItemName")),
                                 game,
                                 (float)reader.GetDouble(reader.GetOrdinal("Price")),
-                                reader.GetString(reader.GetOrdinal("Description")));
+                                reader.GetString(reader.GetOrdinal("GameDescription")));
                             item.SetItemId(reader.GetInt32(reader.GetOrdinal("ItemId")));
                             item.SetIsListed(reader.GetBoolean(reader.GetOrdinal("IsListed")));
                             items.Add(item);
@@ -117,19 +117,19 @@ namespace Steampunks.Repository.Inventory
                     i.ItemId,
                     i.ItemName,
                     i.Price,
-                    i.Description,
+                    i.GameDescription,
                     i.IsListed,
                     g.GameId,
-                    g.Title as GameTitle,
+                    g.GameTitle as GameTitle,
                     g.Genre,
-                    g.Description as GameDescription,
+                    g.GameDescription as GameDescription,
                     g.Price as GamePrice,
                     g.Status as GameStatus
                 FROM Items i
                 JOIN Games g ON i.CorrespondingGameId = g.GameId
                 JOIN UserInventory ui ON i.ItemId = ui.ItemId AND g.GameId = ui.GameId
                 WHERE ui.UserId = @UserId
-                ORDER BY g.Title, i.Price";
+                ORDER BY g.GameTitle, i.Price";
 
             try
             {
@@ -158,7 +158,7 @@ namespace Steampunks.Repository.Inventory
                                 reader.GetString(reader.GetOrdinal("ItemName")),
                                 game,
                                 (float)reader.GetDouble(reader.GetOrdinal("Price")),
-                                reader.GetString(reader.GetOrdinal("Description")));
+                                reader.GetString(reader.GetOrdinal("GameDescription")));
                             item.SetItemId(reader.GetInt32(reader.GetOrdinal("ItemId")));
                             item.SetIsListed(reader.GetBoolean(reader.GetOrdinal("IsListed")));
 
@@ -211,12 +211,12 @@ namespace Steampunks.Repository.Inventory
                     i.ItemId,
                     i.ItemName,
                     i.Price,
-                    i.Description,
+                    i.GameDescription,
                     i.IsListed,
                     g.GameId,
-                    g.Title as GameTitle,
+                    g.GameTitle as GameTitle,
                     g.Genre,
-                    g.Description as GameDescription,
+                    g.GameDescription as GameDescription,
                     g.Price as GamePrice,
                     g.Status as GameStatus
                 FROM Items i
@@ -246,7 +246,7 @@ namespace Steampunks.Repository.Inventory
                                 reader.GetString(reader.GetOrdinal("ItemName")),
                                 game,
                                 (float)reader.GetDouble(reader.GetOrdinal("Price")),
-                                reader.GetString(reader.GetOrdinal("Description")));
+                                reader.GetString(reader.GetOrdinal("GameDescription")));
                             item.SetItemId(reader.GetInt32(reader.GetOrdinal("ItemId")));
                             item.SetIsListed(reader.GetBoolean(reader.GetOrdinal("IsListed")));
                             items.Add(item);
@@ -404,7 +404,7 @@ namespace Steampunks.Repository.Inventory
         public async Task<List<User>> GetAllUsersAsync()
         {
             var users = new List<User>();
-            using (var command = new SqlCommand("SELECT UserId, Username FROM Users", this.dataBaseConnector.GetConnection()))
+            using (var command = new SqlCommand("SELECT UserId, UserName FROM Users", this.dataBaseConnector.GetConnection()))
             {
                 try
                 {
@@ -413,7 +413,7 @@ namespace Steampunks.Repository.Inventory
                     {
                         while (await reader.ReadAsync().ConfigureAwait(false))
                         {
-                            var user = new User(reader.GetString(reader.GetOrdinal("Username")));
+                            var user = new User(reader.GetString(reader.GetOrdinal("UserName")));
                             user.SetUserId(reader.GetInt32(reader.GetOrdinal("UserId")));
                             users.Add(user);
                         }

--- a/Source/ArtAttack/Repository/Marketplace/MarketplaceRepository.cs
+++ b/Source/ArtAttack/Repository/Marketplace/MarketplaceRepository.cs
@@ -153,8 +153,8 @@ namespace Steampunks.Repository.Marketplace
         {
             var items = new List<Item>();
             using (var command = new SqlCommand(
-                @"SELECT i.ItemId, i.ItemName, i.Description, i.Price, i.IsListed,
-                g.GameId, g.Title as GameTitle, g.Price as GamePrice, g.Genre, g.Description as GameDescription
+                @"SELECT i.ItemId, i.ItemName, i.GameDescription, i.Price, i.IsListed,
+                g.GameId, g.GameTitle as GameTitle, g.Price as GamePrice, g.Genre, g.GameDescription as GameDescription
                 FROM Items i
                 JOIN Games g ON i.CorrespondingGameId = g.GameId
                 WHERE i.IsListed = 1",
@@ -178,7 +178,7 @@ namespace Steampunks.Repository.Marketplace
                                 reader.GetString(reader.GetOrdinal("ItemName")),
                                 game,
                                 (float)reader.GetDouble(reader.GetOrdinal("Price")),
-                                reader.GetString(reader.GetOrdinal("Description")));
+                                reader.GetString(reader.GetOrdinal("GameDescription")));
                             item.SetItemId(reader.GetInt32(reader.GetOrdinal("ItemId")));
                             item.SetIsListed(reader.GetBoolean(reader.GetOrdinal("IsListed")));
 
@@ -214,8 +214,8 @@ namespace Steampunks.Repository.Marketplace
         {
             var items = new List<Item>();
             const string query = @"
-                    SELECT i.ItemId, i.ItemName, i.Price, i.Description, i.IsListed,
-                        g.GameId, g.Title as GameTitle, g.Genre, g.Description as GameDescription,
+                    SELECT i.ItemId, i.ItemName, i.Price, i.GameDescription, i.IsListed,
+                        g.GameId, g.GameTitle as GameTitle, g.Genre, g.GameDescription as GameDescription,
                         g.Price as GamePrice, g.Status as GameStatus
                     FROM Items i
                     JOIN UserInventory ui ON i.ItemId = ui.ItemId
@@ -244,7 +244,7 @@ namespace Steampunks.Repository.Marketplace
                                 reader.GetString(reader.GetOrdinal("ItemName")),
                                 gameObject,
                                 (float)reader.GetDouble(reader.GetOrdinal("Price")),
-                                reader.GetString(reader.GetOrdinal("Description")));
+                                reader.GetString(reader.GetOrdinal("GameDescription")));
                             item.SetItemId(reader.GetInt32(reader.GetOrdinal("ItemId")));
                             item.SetIsListed(reader.GetBoolean(reader.GetOrdinal("IsListed")));
                             items.Add(item);

--- a/Source/ArtAttack/Repository/Trade/TradeRepository.cs
+++ b/Source/ArtAttack/Repository/Trade/TradeRepository.cs
@@ -43,9 +43,9 @@ namespace Steampunks.Repository.Trade
             var trades = new List<ItemTrade>();
             const string tradesQuery = @"
                 SELECT t.*, 
-                       su.UserId as SourceUserId, su.Username as SourceUsername,
-                       du.UserId as DestUserId, du.Username as DestUsername,
-                       g.GameId, g.Title as GameTitle, g.Price as GamePrice, g.Genre, g.Description as GameDescription
+                       su.UserId as SourceUserId, su.UserName as SourceUsername,
+                       du.UserId as DestUserId, du.UserName as DestUsername,
+                       g.GameId, g.GameTitle as GameTitle, g.Price as GamePrice, g.Genre, g.GameDescription as GameDescription
                 FROM ItemTrades t
                 JOIN Users su ON t.SourceUserId = su.UserId
                 JOIN Users du ON t.DestinationUserId = du.UserId
@@ -55,7 +55,7 @@ namespace Steampunks.Repository.Trade
 
             const string itemsQuery = @"
                 SELECT i.*, td.IsSourceUserItem,
-                       g.GameId, g.Title as GameTitle, g.Price as GamePrice, g.Genre, g.Description as GameDescription
+                       g.GameId, g.GameTitle as GameTitle, g.Price as GamePrice, g.Genre, g.GameDescription as GameDescription
                 FROM ItemTradeDetails td
                 JOIN Items i ON td.ItemId = i.ItemId
                 JOIN Games g ON i.CorrespondingGameId = g.GameId
@@ -133,7 +133,7 @@ namespace Steampunks.Repository.Trade
                                     reader.GetString(reader.GetOrdinal("ItemName")),
                                     game,
                                     (float)reader.GetDouble(reader.GetOrdinal("Price")),
-                                    reader.GetString(reader.GetOrdinal("Description")));
+                                    reader.GetString(reader.GetOrdinal("GameDescription")));
                                 item.SetItemId(reader.GetInt32(reader.GetOrdinal("ItemId")));
                                 item.SetIsListed(reader.GetBoolean(reader.GetOrdinal("IsListed")));
 
@@ -161,9 +161,9 @@ namespace Steampunks.Repository.Trade
             var trades = new List<ItemTrade>();
             const string tradesQuery = @"
                 SELECT t.*, 
-                       su.UserId as SourceUserId, su.Username as SourceUsername,
-                       du.UserId as DestUserId, du.Username as DestUsername,
-                       g.GameId, g.Title as GameTitle, g.Price as GamePrice, g.Genre, g.Description as GameDescription
+                       su.UserId as SourceUserId, su.UserName as SourceUsername,
+                       du.UserId as DestUserId, du.UserName as DestUsername,
+                       g.GameId, g.GameTitle as GameTitle, g.Price as GamePrice, g.Genre, g.GameDescription as GameDescription
                 FROM ItemTrades t
                 JOIN Users su ON t.SourceUserId = su.UserId
                 JOIN Users du ON t.DestinationUserId = du.UserId
@@ -173,7 +173,7 @@ namespace Steampunks.Repository.Trade
 
             const string itemsQuery = @"
                 SELECT i.*, td.IsSourceUserItem,
-                       g.GameId, g.Title as GameTitle, g.Price as GamePrice, g.Genre, g.Description as GameDescription
+                       g.GameId, g.GameTitle as GameTitle, g.Price as GamePrice, g.Genre, g.GameDescription as GameDescription
                 FROM ItemTradeDetails td
                 JOIN Items i ON td.ItemId = i.ItemId
                 JOIN Games g ON i.CorrespondingGameId = g.GameId
@@ -251,7 +251,7 @@ namespace Steampunks.Repository.Trade
                                     reader.GetString(reader.GetOrdinal("ItemName")),
                                     game,
                                     (float)reader.GetDouble(reader.GetOrdinal("Price")),
-                                    reader.GetString(reader.GetOrdinal("Description")));
+                                    reader.GetString(reader.GetOrdinal("GameDescription")));
 
                                 item.SetItemId(reader.GetInt32(reader.GetOrdinal("ItemId")));
                                 item.SetIsListed(reader.GetBoolean(reader.GetOrdinal("IsListed")));
@@ -480,13 +480,13 @@ namespace Steampunks.Repository.Trade
             using (var connection = this.dataBaseConnector.GetNewConnection())
             {
                 await connection.OpenAsync();
-                using (var command = new SqlCommand("SELECT TOP 1 UserId, Username FROM Users", connection))
+                using (var command = new SqlCommand("SELECT TOP 1 UserId, UserName FROM Users", connection))
                 {
                     using (var reader = await command.ExecuteReaderAsync())
                     {
                         if (await reader.ReadAsync())
                         {
-                            var user = new User(reader.GetString(reader.GetOrdinal("Username")));
+                            var user = new User(reader.GetString(reader.GetOrdinal("UserName")));
                             user.SetUserId(reader.GetInt32(reader.GetOrdinal("UserId")));
                             return user;
                         }
@@ -506,19 +506,19 @@ namespace Steampunks.Repository.Trade
                     i.ItemId,
                     i.ItemName,
                     i.Price,
-                    i.Description,
+                    i.GameDescription,
                     i.IsListed,
                     g.GameId,
-                    g.Title as GameTitle,
+                    g.GameTitle as GameTitle,
                     g.Genre,
-                    g.Description as GameDescription,
+                    g.GameDescription as GameDescription,
                     g.Price as GamePrice,
                     g.Status as GameStatus
                 FROM Items i
                 JOIN Games g ON i.CorrespondingGameId = g.GameId
                 JOIN UserInventory ui ON i.ItemId = ui.ItemId AND g.GameId = ui.GameId
                 WHERE ui.UserId = @UserId
-                ORDER BY g.Title, i.Price";
+                ORDER BY g.GameTitle, i.Price";
 
             try
             {
@@ -549,7 +549,7 @@ namespace Steampunks.Repository.Trade
                                     reader.GetString(reader.GetOrdinal("ItemName")),
                                     game,
                                     (float)reader.GetDouble(reader.GetOrdinal("Price")),
-                                    reader.GetString(reader.GetOrdinal("Description")));
+                                    reader.GetString(reader.GetOrdinal("GameDescription")));
                                 item.SetItemId(reader.GetInt32(reader.GetOrdinal("ItemId")));
                                 item.SetIsListed(reader.GetBoolean(reader.GetOrdinal("IsListed")));
 
@@ -585,17 +585,17 @@ namespace Steampunks.Repository.Trade
             try
             {
                 // Get the game folder name based on the game title
-                string gameFolder = item.Game.Title.ToLower() switch
+                string gameFolder = item.Game.GameTitle.ToLower() switch
                 {
                     "counter-strike 2" => "cs2",
                     "dota 2" => "dota2",
                     "team fortress 2" => "tf2",
-                    _ => item.Game.Title.ToLower().Replace(" ", string.Empty).Replace(":", string.Empty)
+                    _ => item.Game.GameTitle.ToLower().Replace(" ", string.Empty).Replace(":", string.Empty)
                 };
 
                 // Return a path to the image based on the ItemId
                 var path = $"ms-appx:///Assets/img/games/{gameFolder}/{item.ItemId}.png";
-                System.Diagnostics.Debug.WriteLine($"Generated image path for item {item.ItemId} ({item.ItemName}) from {item.Game.Title}: {path}");
+                System.Diagnostics.Debug.WriteLine($"Generated image path for item {item.ItemId} ({item.ItemName}) from {item.Game.GameTitle}: {path}");
                 return path;
             }
             catch (Exception getItemImagePathException)

--- a/Source/ArtAttack/Repository/User/UserRepository.cs
+++ b/Source/ArtAttack/Repository/User/UserRepository.cs
@@ -44,7 +44,7 @@ namespace Steampunks.Repository.UserRepository
         public async Task<List<User>> GetAllUsersAsync()
         {
             var users = new List<User>();
-            const string query = "SELECT UserId, Username FROM Users";
+            const string query = "SELECT UserId, UserName FROM Users";
 
             try
             {
@@ -57,7 +57,7 @@ namespace Steampunks.Repository.UserRepository
                     {
                         while (await reader.ReadAsync())
                         {
-                            var user = new User(reader.GetString(reader.GetOrdinal("Username")));
+                            var user = new User(reader.GetString(reader.GetOrdinal("UserName")));
                             user.SetUserId(reader.GetInt32(reader.GetOrdinal("UserId")));
                             users.Add(user);
                         }
@@ -90,7 +90,7 @@ namespace Steampunks.Repository.UserRepository
         public async Task<User?> GetUserByIdAsync(int userId)
         {
             const string query = @"
-        SELECT UserId, Username, WalletBalance, PointBalance, IsDeveloper
+        SELECT UserId, UserName, WalletBalance, PointBalance, IsDeveloper
         FROM Users
         WHERE UserId = @UserId";
 
@@ -106,7 +106,7 @@ namespace Steampunks.Repository.UserRepository
                     {
                         if (await reader.ReadAsync())
                         {
-                            var user = new User(reader.GetString(reader.GetOrdinal("Username")));
+                            var user = new User(reader.GetString(reader.GetOrdinal("UserName")));
                             user.SetUserId(reader.GetInt32(reader.GetOrdinal("UserId")));
                             return user;
                         }
@@ -132,7 +132,7 @@ namespace Steampunks.Repository.UserRepository
         {
             const string query = @"
         UPDATE Users
-        SET Username = @Username,
+        SET UserName = @UserName,
             WalletBalance = @WalletBalance,
             PointBalance = @PointBalance,
             IsDeveloper = @IsDeveloper
@@ -144,7 +144,7 @@ namespace Steampunks.Repository.UserRepository
                 using (var command = new SqlCommand(query, connection))
                 {
                     command.Parameters.AddWithValue("@UserId", user.UserId);
-                    command.Parameters.AddWithValue("@Username", user.Username);
+                    command.Parameters.AddWithValue("@UserName", user.UserName);
                     command.Parameters.AddWithValue("@WalletBalance", user.WalletBalance);
                     command.Parameters.AddWithValue("@PointBalance", user.PointBalance);
                     command.Parameters.AddWithValue("@IsDeveloper", user.IsDeveloper);
@@ -174,8 +174,8 @@ namespace Steampunks.Repository.UserRepository
                 "TestUser3",
             };
 
-            const string query = @"INSERT INTO Users (Username, WalletBalance, PointBalance, IsDeveloper) 
-                  VALUES (@Username, 1000, 100, 0)";
+            const string query = @"INSERT INTO Users (UserName, WalletBalance, PointBalance, IsDeveloper) 
+                  VALUES (@UserName, 1000, 100, 0)";
 
             try
             {
@@ -187,7 +187,7 @@ namespace Steampunks.Repository.UserRepository
                     foreach (var username in testUsers)
                     {
                         command.Parameters.Clear();
-                        command.Parameters.AddWithValue("@Username", username);
+                        command.Parameters.AddWithValue("@UserName", username);
                         await command.ExecuteNonQueryAsync();
                     }
                 }

--- a/Source/ArtAttack/Services/InventoryService/InventoryService.cs
+++ b/Source/ArtAttack/Services/InventoryService/InventoryService.cs
@@ -105,7 +105,7 @@ namespace Steampunks.Services.InventoryService.InventoryService
             var filteredItems = items.Where(item => !item.IsListed);
 
             // If a specific game is selected (not the "All Games" option), filter by that game.
-            if (selectedGame != null && selectedGame.Title != "All Games")
+            if (selectedGame != null && selectedGame.GameTitle != "All Games")
             {
                 filteredItems = filteredItems.Where(item =>
                     item.Game != null && item.Game.GameId == selectedGame.GameId);

--- a/Source/ArtAttack/Validators/InventoryValidators/InventoryValidator.cs
+++ b/Source/ArtAttack/Validators/InventoryValidators/InventoryValidator.cs
@@ -21,7 +21,7 @@ namespace Steampunks.Validators.InventoryValidators
                 throw new ArgumentNullException(nameof(game), "Game cannot be null.");
             }
 
-            if (string.IsNullOrWhiteSpace(game.Title))
+            if (string.IsNullOrWhiteSpace(game.GameTitle))
             {
                 throw new ArgumentException("Game title cannot be null or empty.", nameof(game));
             }
@@ -66,7 +66,7 @@ namespace Steampunks.Validators.InventoryValidators
                 throw new ArgumentNullException(nameof(user), "User cannot be null.");
             }
 
-            if (string.IsNullOrWhiteSpace(user.Username))
+            if (string.IsNullOrWhiteSpace(user.UserName))
             {
                 throw new ArgumentException("User username cannot be null or empty.", nameof(user));
             }

--- a/Source/ArtAttack/ViewModels/MarketplaceViewModel.cs
+++ b/Source/ArtAttack/ViewModels/MarketplaceViewModel.cs
@@ -247,7 +247,7 @@ namespace Steampunks.ViewModels
         private void InitializeCollections()
         {
             var allItems = this.Items.ToList();
-            this.AvailableGames = new ObservableCollection<string>(allItems.Select(item => item.Game.Title).Distinct());
+            this.AvailableGames = new ObservableCollection<string>(allItems.Select(item => item.Game.GameTitle).Distinct());
             this.AvailableTypes = new ObservableCollection<string>(allItems.Select(item => item.ItemName.Split('|').First().Trim()).Distinct());
             this.AvailableRarities = new ObservableCollection<string>(new[] { "Common", "Uncommon", "Rare", "Epic", "Legendary" });
         }
@@ -266,7 +266,7 @@ namespace Steampunks.ViewModels
 
             if (!string.IsNullOrEmpty(this.SelectedGame))
             {
-                filteredItems = filteredItems.Where(item => item.Game.Title == this.SelectedGame);
+                filteredItems = filteredItems.Where(item => item.Game.GameTitle == this.SelectedGame);
             }
 
             if (!string.IsNullOrEmpty(this.SelectedType))

--- a/Source/ArtAttack/Views/TradingPage.xaml
+++ b/Source/ArtAttack/Views/TradingPage.xaml
@@ -283,7 +283,7 @@
                                     Width="200">
                                 <ComboBox.ItemTemplate>
                                     <DataTemplate x:DataType="models:User">
-                                        <TextBlock Text="{x:Bind Username}"/>
+                                        <TextBlock Text="{x:Bind UserName}"/>
                                     </DataTemplate>
                                 </ComboBox.ItemTemplate>
                             </ComboBox>
@@ -318,7 +318,7 @@
 
                                         <!-- Source User Items -->
                                         <StackPanel Grid.Row="1" Margin="0,0,0,10">
-                                            <TextBlock Text="{x:Bind SourceUser.Username}" 
+                                            <TextBlock Text="{x:Bind SourceUser.UserName}" 
                                                      Style="{StaticResource SubtitleTextBlockStyle}"/>
                                             <ItemsRepeater ItemsSource="{x:Bind SourceUserItems}">
                                                 <ItemsRepeater.ItemTemplate>
@@ -332,7 +332,7 @@
 
                                         <!-- Destination User Items -->
                                         <StackPanel Grid.Row="2">
-                                            <TextBlock Text="{x:Bind DestinationUser.Username}" 
+                                            <TextBlock Text="{x:Bind DestinationUser.UserName}" 
                                                      Style="{StaticResource SubtitleTextBlockStyle}"/>
                                             <ItemsRepeater ItemsSource="{x:Bind DestinationUserItems}">
                                                 <ItemsRepeater.ItemTemplate>
@@ -382,7 +382,7 @@
                                     Width="200">
                                 <ComboBox.ItemTemplate>
                                     <DataTemplate x:DataType="models:User">
-                                        <TextBlock Text="{x:Bind Username}"/>
+                                        <TextBlock Text="{x:Bind UserName}"/>
                                     </DataTemplate>
                                 </ComboBox.ItemTemplate>
                             </ComboBox>
@@ -425,7 +425,7 @@
 
                                         <!-- Source User Items -->
                                         <StackPanel Grid.Column="1" Margin="0,0,0,10">
-                                            <TextBlock Text="{x:Bind SourceUser.Username}" 
+                                            <TextBlock Text="{x:Bind SourceUser.UserName}" 
                                                      Style="{StaticResource SubtitleTextBlockStyle}"/>
                                             <ItemsRepeater ItemsSource="{x:Bind SourceUserItems}">
                                                 <ItemsRepeater.ItemTemplate>
@@ -439,7 +439,7 @@
 
                                         <!-- Destination User Items -->
                                         <StackPanel Grid.Column="2">
-                                            <TextBlock Text="{x:Bind DestinationUser.Username}" 
+                                            <TextBlock Text="{x:Bind DestinationUser.UserName}" 
                                                      Style="{StaticResource SubtitleTextBlockStyle}"/>
                                             <ItemsRepeater ItemsSource="{x:Bind DestinationUserItems}">
                                                 <ItemsRepeater.ItemTemplate>

--- a/Source/ArtAttack/Views/TradingPage.xaml.cs
+++ b/Source/ArtAttack/Views/TradingPage.xaml.cs
@@ -32,14 +32,14 @@ namespace Steampunks.Views
     public sealed partial class TradingPage : Page
     {
         // Constants (avoid magic strings)
-        private const string DisplayMemberUsername = "Username";
+        private const string DisplayMemberUsername = "UserName";
         private const string LoadUsersErrorMessage = "Error loading users. Please try again later.";
         private const string LoadUsersDebugMessagePrefix = "Error loading users: ";
         private const string LoadUserItemsErrorMessage = "Error loading your items. Please try again later.";
         private const string LoadUserItemsDebugMessagePrefix = "Error loading user items: ";
         private const string LoadRecipientItemsErrorMessage = "Error loading recipient's items. Please try again later.";
         private const string LoadRecipientItemsDebugMessagePrefix = "Error loading recipient items: ";
-        private const string GameDisplayMemberPath = "Title";
+        private const string GameDisplayMemberPath = "GameTitle";
         private const string LoadGamesErrorPrefix = "Error loading games: ";
         private const string LoadGamesInnerErrorPrefix = "Inner error: ";
         private const string LoadGamesSuccessMessagePrefix = "Successfully loaded ";
@@ -344,7 +344,7 @@ namespace Steampunks.Views
                     this.TradeHistory.Add(new TradeHistoryViewModel
                     {
                         TradeId = trade.TradeId,
-                        PartnerName = tradePartner.Username,
+                        PartnerName = tradePartner.UserName,
                         TradeItems = trade.SourceUserItems.Concat(trade.DestinationUserItems).ToList(),
                         TradeDescription = trade.TradeDescription,
                         TradeStatus = trade.TradeStatus,

--- a/Source/CtrlAltElite.Tests/Repositories/CartRepositoryTests.cs
+++ b/Source/CtrlAltElite.Tests/Repositories/CartRepositoryTests.cs
@@ -20,7 +20,7 @@ public class CartRepositoryTests
 		dataLinkMock = new Mock<IDataLink>();
 		testUser = new User
 		{
-			UserIdentifier = TestUserIdentifier,
+			UserId = TestUserIdentifier,
 			WalletBalance = TestWalletBallance
 		};
 		cartRepository = new CartRepository(dataLinkMock.Object, testUser);
@@ -40,7 +40,7 @@ public class CartRepositoryTests
 		var row = table.NewRow();
 		row[SqlConstants.GAMEIDCOLUMN] = 1;
 		row[SqlConstants.NAMECOLUMN] = "GameName";
-		row[SqlConstants.DESCRIPTIONCOLUMN] = "Description";
+		row[SqlConstants.DESCRIPTIONCOLUMN] = "GameDescription";
 		row[SqlConstants.IMAGEURLCOLUMN] = "image.png";
 		row[SqlConstants.PRICECOLUMN] = 19.99m;
 		table.Rows.Add(row);
@@ -78,7 +78,7 @@ public class CartRepositoryTests
 	[Fact]
 	public void AddGameToCart_WhenCalledValidIdentifier_ShouldExecuteQuery()
 	{
-		var game = new Game { Identifier = TestUserIdentifier };
+		var game = new Game { GameId = TestUserIdentifier };
 
 		cartRepository.AddGameToCart(game);
 
@@ -89,7 +89,7 @@ public class CartRepositoryTests
 	[Fact]
 	public void AddGameToCart_WhenDataLinkFails_ShouldThrowWrappedException()
 	{
-		var game = new Game { Identifier = TestUserIdentifier };
+		var game = new Game { GameId = TestUserIdentifier };
 		var expectedExceptionErrorMessage = "SQL error";
 
 		dataLinkMock
@@ -104,7 +104,7 @@ public class CartRepositoryTests
 	[Fact]
 	public void RemoveGameFromCart_WhenCalledWithValidIdentifier_ShouldExecuteQuery()
 	{
-		var game = new Game { Identifier = TestUserIdentifier };
+		var game = new Game { GameId = TestUserIdentifier };
 
 		cartRepository.RemoveGameFromCart(game);
 
@@ -115,7 +115,7 @@ public class CartRepositoryTests
 	[Fact]
 	public void RemoveGameFromCart_WhenExceptionIsThrownByDataLink_ShouldCatchExceptionAndNotThrow()
 	{
-		var game = new Game { Identifier = TestUserIdentifier };
+		var game = new Game { GameId = TestUserIdentifier };
 		var expectedExceptionErrorMessage = "Something went wrong";
 
 		dataLinkMock

--- a/Source/CtrlAltElite.Tests/Repositories/GameRepositoryTest.cs
+++ b/Source/CtrlAltElite.Tests/Repositories/GameRepositoryTest.cs
@@ -8,9 +8,9 @@ public class GameRepositoryTest : IDisposable
 {
     private Game templateTestGame = new Game()
     {
-        Identifier = (int)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
-        Name = "TestName",
-        Description = "TestDescription",
+        GameId = (int)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+        GameTitle = "TestName",
+        GameDescription = "TestDescription",
         ImagePath = "TestImagePath",
         Price = 1.99m,
         TrailerPath = "TestTrailerPath",
@@ -41,7 +41,7 @@ public class GameRepositoryTest : IDisposable
 
         // Assert
         var foundGame = subject.GetDeveloperGames(testGame.PublisherIdentifier)
-            .FirstOrDefault(game => game.Name == testGame.Name);
+            .FirstOrDefault(game => game.GameTitle == testGame.GameTitle);
         AssertUtils.AssertAllPropertiesEqual(testGame, foundGame);
     }
 
@@ -52,9 +52,9 @@ public class GameRepositoryTest : IDisposable
         var insertedGame = CreateTestGame();
         var updatedGame = new Game()
         {
-            Identifier = insertedGame.Identifier,
-            Name = "TestNameUpdated",
-            Description = "TestDescriptionUpdated",
+            GameId = insertedGame.GameId,
+            GameTitle = "TestNameUpdated",
+            GameDescription = "TestDescriptionUpdated",
             ImagePath = "TestImagePathUpdated",
             Price = 9.99m,
             TrailerPath = "TestTrailerPathUpdated",
@@ -67,14 +67,14 @@ public class GameRepositoryTest : IDisposable
             PublisherIdentifier = 1
         };
         updatedGame.Rating = UPDATED_GAME_RATING;
-        updatedGame.Identifier = insertedGame.Identifier;
+        updatedGame.GameId = insertedGame.GameId;
 
         // Act
-        subject.UpdateGame(updatedGame.Identifier, updatedGame);
+        subject.UpdateGame(updatedGame.GameId, updatedGame);
 
         // Assert
         var foundGame = subject.GetDeveloperGames(updatedGame.PublisherIdentifier)
-            .FirstOrDefault(game => game.Name == updatedGame.Name);
+            .FirstOrDefault(game => game.GameTitle == updatedGame.GameTitle);
         AssertUtils.AssertAllPropertiesEqual(updatedGame, foundGame);
     }
 
@@ -85,11 +85,11 @@ public class GameRepositoryTest : IDisposable
         var testGame = CreateTestGame(PENDING_STATUS);
 
         // Act
-        subject.ValidateGame(testGame.Identifier);
+        subject.ValidateGame(testGame.GameId);
 
         // Assert
         var foundGame = subject.GetDeveloperGames(testGame.PublisherIdentifier)
-            .FirstOrDefault(game => game.Name == testGame.Name);
+            .FirstOrDefault(game => game.GameTitle == testGame.GameTitle);
         Assert.Equal(APPROVED_STATUS, foundGame!.Status);
     }
 
@@ -100,11 +100,11 @@ public class GameRepositoryTest : IDisposable
         var testGame = CreateTestGame(PENDING_STATUS);
 
         // Act
-        subject.RejectGame(testGame.Identifier);
+        subject.RejectGame(testGame.GameId);
 
         // Assert
         var foundGame = subject.GetDeveloperGames(testGame.PublisherIdentifier)
-            .FirstOrDefault(game => game.Name == testGame.Name);
+            .FirstOrDefault(game => game.GameTitle == testGame.GameTitle);
         Assert.Equal(REJECTED_STATUS, foundGame!.Status);
     }
 
@@ -115,10 +115,10 @@ public class GameRepositoryTest : IDisposable
         var testGame = CreateTestGame(PENDING_STATUS);
 
         // Act
-        subject.RejectGame(testGame.Identifier);
+        subject.RejectGame(testGame.GameId);
 
         // Assert
-        Assert.Equal(string.Empty, subject.GetRejectionMessage(testGame.Identifier));
+        Assert.Equal(string.Empty, subject.GetRejectionMessage(testGame.GameId));
     }
 
     [Fact]
@@ -138,11 +138,11 @@ public class GameRepositoryTest : IDisposable
         var testGame = CreateTestGame(PENDING_STATUS);
 
         // Act
-        subject.RejectGameWithMessage(testGame.Identifier, TEST_MESSAGE);
+        subject.RejectGameWithMessage(testGame.GameId, TEST_MESSAGE);
 
         // Assert
         var foundGame = subject.GetDeveloperGames(testGame.PublisherIdentifier)
-            .FirstOrDefault(game => game.Name == testGame.Name);
+            .FirstOrDefault(game => game.GameTitle == testGame.GameTitle);
         Assert.Equal(REJECTED_STATUS, foundGame!.Status);
     }
 
@@ -153,10 +153,10 @@ public class GameRepositoryTest : IDisposable
         var testGame = CreateTestGame(PENDING_STATUS);
 
         // Act
-        subject.RejectGameWithMessage(testGame.Identifier, TEST_MESSAGE);
+        subject.RejectGameWithMessage(testGame.GameId, TEST_MESSAGE);
 
         // Assert
-        Assert.Equal(TEST_MESSAGE, subject.GetRejectionMessage(testGame.Identifier));
+        Assert.Equal(TEST_MESSAGE, subject.GetRejectionMessage(testGame.GameId));
     }
 
     [Fact]
@@ -170,7 +170,7 @@ public class GameRepositoryTest : IDisposable
         testGame.TagScore = Game.NOTCOMPUTED;
 
         // Act
-        var foundGame = subject.GetAllGames().FirstOrDefault(game => game.Name == testGame.Name);
+        var foundGame = subject.GetAllGames().FirstOrDefault(game => game.GameTitle == testGame.GameTitle);
 
         // Assert
         AssertUtils.AssertAllPropertiesEqual(testGame, foundGame);
@@ -184,7 +184,7 @@ public class GameRepositoryTest : IDisposable
 
         // Act
         var foundGame = subject.GetUnvalidated(TEST_UNVALIDATED_USER_ID)
-            .FirstOrDefault(game => game.Name == testGame.Name);
+            .FirstOrDefault(game => game.GameTitle == testGame.GameTitle);
 
         // Assert
         AssertUtils.AssertAllPropertiesEqual(testGame, foundGame);
@@ -198,11 +198,11 @@ public class GameRepositoryTest : IDisposable
         CreateTagsForGame(testGame);
 
         // Act
-        subject.DeleteGame(testGame.Identifier);
+        subject.DeleteGame(testGame.GameId);
 
         // Assert
         var notFound = subject.GetDeveloperGames(testGame.PublisherIdentifier)
-            .FirstOrDefault(game => game.Name == testGame.Name);
+            .FirstOrDefault(game => game.GameTitle == testGame.GameTitle);
         Assert.Null(notFound);
     }
 
@@ -213,7 +213,7 @@ public class GameRepositoryTest : IDisposable
         var testGame = CreateTestGame();
 
         // Act
-        var isGameIdInUse = subject.IsGameIdInUse(testGame.Identifier);
+        var isGameIdInUse = subject.IsGameIdInUse(testGame.GameId);
 
         // Assert
         Assert.True(isGameIdInUse);
@@ -234,7 +234,7 @@ public class GameRepositoryTest : IDisposable
         var tags = TagsConstants.ALL_TAGS.OrderBy(tag => tag.Tag_name).ToArray();
         foreach (var tag in tags)
         {
-            subject.InsertGameTag(testGame.Identifier, tag.TagId);
+            subject.InsertGameTag(testGame.GameId, tag.TagId);
         }
 
         return tags;
@@ -254,6 +254,6 @@ public class GameRepositoryTest : IDisposable
 
     public void Dispose()
     {
-        subject.DeleteGame(templateTestGame.Identifier);
+        subject.DeleteGame(templateTestGame.GameId);
     }
 }

--- a/Source/CtrlAltElite.Tests/Repositories/PointShopRepositoryTest.cs
+++ b/Source/CtrlAltElite.Tests/Repositories/PointShopRepositoryTest.cs
@@ -34,8 +34,8 @@ namespace SteamStore.Tests.Repositories
         {
             testUser = new User
             {
-                UserIdentifier = ValidUserId,
-                Name = ValidUserName,
+                UserId = ValidUserId,
+                UserName = ValidUserName,
                 PointsBalance = InitialUserPoints
             };
 

--- a/Source/CtrlAltElite.Tests/Repositories/UserGameRepositoryTest.cs
+++ b/Source/CtrlAltElite.Tests/Repositories/UserGameRepositoryTest.cs
@@ -26,7 +26,7 @@ namespace SteamStore.Tests.Repositories
         public UserGameRepositoryTest()
         {
             mockDataLink = new Mock<IDataLink>();
-            mockUser = new User { UserIdentifier = TestUserIdentifier, WalletBalance = InitialWalletBalance, PointsBalance = InitialPointsBalance };
+            mockUser = new User { UserId = TestUserIdentifier, WalletBalance = InitialWalletBalance, PointsBalance = InitialPointsBalance };
             userGameRepository = new UserGameRepository(mockDataLink.Object, mockUser);
         }
 
@@ -34,7 +34,7 @@ namespace SteamStore.Tests.Repositories
         public void IsGamePurchased_WhenGameIsPurchased_ShouldReturnTrue()
         {
             const int ItemWasPurchased = 1;
-            var purchasedGame = new Game { Identifier = TestGameIdentifier };
+            var purchasedGame = new Game { GameId = TestGameIdentifier };
             mockDataLink.Setup(dataLink => dataLink.ExecuteScalar<int>(SqlConstants.IsGamePurchasedProcedure, It.IsAny<SqlParameter[]>()))
                         .Returns(ItemWasPurchased);
 
@@ -47,7 +47,7 @@ namespace SteamStore.Tests.Repositories
         public void IsGamePurchased_WhenGameIsNotPurchased_ShouldReturnFalse()
         {
             const int ItemWasNotPurchased = 0;
-            var unpurchasedGame = new Game { Identifier = TestGameIdentifier };
+            var unpurchasedGame = new Game { GameId = TestGameIdentifier };
             mockDataLink.Setup(dataLink => dataLink.ExecuteScalar<int>(SqlConstants.IsGamePurchasedProcedure, It.IsAny<SqlParameter[]>()))
                         .Returns(ItemWasNotPurchased);
 
@@ -59,7 +59,7 @@ namespace SteamStore.Tests.Repositories
         [Fact]
         public void RemoveGameFromWishlist_WhenGameIsValid_CallsExecuteNonQuery()
         {
-            var gameToRemove = new Game { Identifier = TestGameIdentifier };
+            var gameToRemove = new Game { GameId = TestGameIdentifier };
             mockDataLink.Setup(dataLink => dataLink.ExecuteNonQuery(SqlConstants.RemoveGameFromWishlistProcedure, It.IsAny<SqlParameter[]>()))
                         .Verifiable();
 
@@ -71,7 +71,7 @@ namespace SteamStore.Tests.Repositories
         [Fact]
         public void RemoveGameFromWishlist_WhenDatabaseErrorOccurs_ThrowsException()
         {
-            var gameToRemove = new Game { Identifier = TestGameIdentifier };
+            var gameToRemove = new Game { GameId = TestGameIdentifier };
             mockDataLink.Setup(dataLink => dataLink.ExecuteNonQuery(SqlConstants.RemoveGameFromWishlistProcedure, It.IsAny<SqlParameter[]>()))
                         .Throws(new Exception(ExceptionMessageDatabaseError));
 
@@ -85,7 +85,7 @@ namespace SteamStore.Tests.Repositories
             const decimal TestGamePriceExpensive = 200.0m;
             const string ExceptionMessageInsufficientFunds = "Insufficient funds";
 
-            var expensiveGame = new Game { Identifier = TestGameIdentifier, Price = TestGamePriceExpensive };
+            var expensiveGame = new Game { GameId = TestGameIdentifier, Price = TestGamePriceExpensive };
             var exceptionAddGameToPurchased = Assert.Throws<Exception>(() => userGameRepository.AddGameToPurchased(expensiveGame));
 
             Assert.Equal(ExceptionMessageInsufficientFunds, exceptionAddGameToPurchased.Message);
@@ -97,7 +97,7 @@ namespace SteamStore.Tests.Repositories
             const decimal TestGamePriceAffordable = 10.0m;
             const float TestGameCheckPrice = 90.0f;
 
-            var affordableGame = new Game { Identifier = TestGameIdentifier, Price = TestGamePriceAffordable };
+            var affordableGame = new Game { GameId = TestGameIdentifier, Price = TestGamePriceAffordable };
             mockDataLink.Setup(dataLink => dataLink.ExecuteNonQuery(SqlConstants.AddGameToPurchasedGamesProcedure, It.IsAny<SqlParameter[]>()))
                         .Verifiable();
 
@@ -110,7 +110,7 @@ namespace SteamStore.Tests.Repositories
         [Fact]
         public void AddGameToWishlist_WhenGameIsValid_CallsExecuteNonQuery()
         {
-            var gameToAdd = new Game { Identifier = TestGameIdentifier };
+            var gameToAdd = new Game { GameId = TestGameIdentifier };
             mockDataLink.Setup(dataLink => dataLink.ExecuteNonQuery(SqlConstants.AddGameToWishlistProcedure, It.IsAny<SqlParameter[]>()))
                         .Verifiable();
 
@@ -122,7 +122,7 @@ namespace SteamStore.Tests.Repositories
         [Fact]
         public void AddGameToWishlist_WhenDatabaseFails_ThrowsException()
         {
-            var gameToAdd = new Game { Identifier = TestGameIdentifier };
+            var gameToAdd = new Game { GameId = TestGameIdentifier };
 
             mockDataLink.Setup(dataLink => dataLink.ExecuteNonQuery(SqlConstants.AddGameToWishlistProcedure, It.IsAny<SqlParameter[]>()))
                         .Throws(new Exception(ExceptionMessageDatabaseError));
@@ -246,7 +246,7 @@ namespace SteamStore.Tests.Repositories
             const int FirstGameIdentifier = 1;
             const string FirstGameName = "FirstGame";
             const decimal FirstGamePrice = 19.99m;
-            const string FirstGameDescription = "FirstGame Description";
+            const string FirstGameDescription = "FirstGame GameDescription";
             const string FirstGameImage = "FirstGame Image";
             const string FirstGameMinimumRequirement = "FirstGame Min";
             const string FirstGameRecommendedRequirement = "FirstGame Recommended";
@@ -257,7 +257,7 @@ namespace SteamStore.Tests.Repositories
             const int SecondGameIdentifier = 2;
             const string SecondGameName = "SecondGame";
             const decimal SecondGamePrice = 29.99m;
-            const string SecondGameDescription = "SecondGame Description";
+            const string SecondGameDescription = "SecondGame GameDescription";
             const string SecondGameImage = "SecondGame Image";
             const string SecondGameMinimumRequirement = "SecondGame Min";
             const string SecondGameRecommendedRequirement = "SecondGame Recommended";

--- a/Source/CtrlAltElite.Tests/Services/CartServiceTests.cs
+++ b/Source/CtrlAltElite.Tests/Services/CartServiceTests.cs
@@ -52,7 +52,7 @@ public class CartServiceTests
 	{
 		var game = new Game
 		{
-			Identifier = TestGameIdentifier
+			GameId = TestGameIdentifier
 		};
 
 		repositoryMock.Setup(repositoryMock => repositoryMock.RemoveGameFromCart(It.IsAny<Game>()))
@@ -68,7 +68,7 @@ public class CartServiceTests
 	{
 		var game = new Game
 		{
-			Identifier = TestGameIdentifier
+			GameId = TestGameIdentifier
 		};
 
 		repositoryMock.Setup(repositoryMock => repositoryMock.AddGameToCart(It.IsAny<Game>()))
@@ -86,11 +86,11 @@ public class CartServiceTests
 		{
 			new Game
 			{
-				Identifier = TestGameIdentifier
+				GameId = TestGameIdentifier
 			},
 			new Game
 			{
-				Identifier = TestSecondGameIdentifier
+				GameId = TestSecondGameIdentifier
 			}
 		};
 
@@ -122,12 +122,12 @@ public class CartServiceTests
 		{
 			new Game
 			{
-				Identifier = TestGameIdentifier,
+				GameId = TestGameIdentifier,
 				Price = TestGamePrice
 			},
 			new Game
 			{
-				Identifier = TestSecondGameIdentifier,
+				GameId = TestSecondGameIdentifier,
 				Price = TestSecondGamePrice
 			}
 		};
@@ -147,12 +147,12 @@ public class CartServiceTests
 		{
 			new Game
 			{
-				Identifier = TestGameIdentifier,
+				GameId = TestGameIdentifier,
 				Price = TestGamePrice
 			},
 			new Game
 			{
-				Identifier = TestSecondGameIdentifier,
+				GameId = TestSecondGameIdentifier,
 				Price = TestSecondGamePrice
 			}
 		};

--- a/Source/CtrlAltElite.Tests/Services/DeveloperServiceTests.cs
+++ b/Source/CtrlAltElite.Tests/Services/DeveloperServiceTests.cs
@@ -37,7 +37,7 @@ namespace SteamStore.Tests.Services
 		private const int TestTagId = 1;
 		private const int TestSecondTagId = 2;
 
-		private readonly User testUser = new User() { UserIdentifier = 42 };
+		private readonly User testUser = new User() { UserId = 42 };
 
 		public DeveloperServiceTests()
 		{
@@ -74,15 +74,15 @@ namespace SteamStore.Tests.Services
 
 			var expectedGame = new Game
 			{
-				Identifier = TestGameId,
-				Description = TestGameDescriptionText,
+				GameId = TestGameId,
+				GameDescription = TestGameDescriptionText,
 				Discount = TestGameDescription,
 				GameplayPath = TestGameGameplayInfoText,
 				ImagePath = TestGameImageInfoText,
 				TrailerPath = TestGameTrailerInfoText,
 				MinimumRequirements = TestGameMinimumRequirementText,
 				RecommendedRequirements = TestGameRecommendedRequirementText,
-				Name = TestGameNameText,
+				GameTitle = TestGameNameText,
 				Price = TestGamePrice,
 				Rating = TestRating,
 				PublisherIdentifier = TestPublisherIdentifier,
@@ -114,7 +114,7 @@ namespace SteamStore.Tests.Services
 		[Fact]
 		public void FindGameInObservableCollectionById_WhenValid_ShouldReturnGame()
 		{
-			var gamesToSearchIn = new ObservableCollection<Game> { new Game { Identifier = TestGameId } };
+			var gamesToSearchIn = new ObservableCollection<Game> { new Game { GameId = TestGameId } };
 
 			var searchedIdentifier = TestGameId;
 
@@ -126,7 +126,7 @@ namespace SteamStore.Tests.Services
 		[Fact]
 		public void CreateGame_WhenValid_ShouldCallRepository()
 		{
-			var gameToCreate = new Game { Identifier = TestGameId };
+			var gameToCreate = new Game { GameId = TestGameId };
 
 			service.CreateGame(gameToCreate);
 
@@ -136,7 +136,7 @@ namespace SteamStore.Tests.Services
 		[Fact]
 		public void CreateGameWithTags_WhenValid_ShouldCallCreate()
 		{
-			var gameToCreate = new Game { Identifier = TestGameId };
+			var gameToCreate = new Game { GameId = TestGameId };
 			var tagsToAttribute = new List<Tag> { new Tag() { TagId = TestSecondTagId } };
 
 			var expectedGameIdentifier = TestGameId;
@@ -150,7 +150,7 @@ namespace SteamStore.Tests.Services
 		[Fact]
 		public void CreateGameWithTags_WhenValid_ShouldCallInsert()
 		{
-			var gameToCreate = new Game { Identifier = TestGameId };
+			var gameToCreate = new Game { GameId = TestGameId };
 			var tagsToAttribute = new List<Tag> { new Tag() { TagId = TestSecondTagId } };
 
 			var expectedGameIdentifier = TestGameId;
@@ -164,7 +164,7 @@ namespace SteamStore.Tests.Services
 		[Fact]
 		public void UpdateGame_WhenValid_ShouldCallUpdateWithUserId()
 		{
-			var gameToUpdate = new Game { Identifier = TestGameId };
+			var gameToUpdate = new Game { GameId = TestGameId };
 
 			var expectedGameIdentifier = TestGameId;
 
@@ -175,7 +175,7 @@ namespace SteamStore.Tests.Services
 		[Fact]
 		public void UpdateGameWithTags_WhenValid_ShouldCallUpdate()
 		{
-			var gameToUpdate = new Game { Identifier = TestGameId };
+			var gameToUpdate = new Game { GameId = TestGameId };
 			var tagsToAttribute = new List<Tag> { new Tag() { TagId = TestSecondTagId } };
 
 			var expectedGameIdentifier = TestGameId;
@@ -189,7 +189,7 @@ namespace SteamStore.Tests.Services
 		[Fact]
 		public void UpdateGameWithTags_WhenValid_ShouldCallDeleteTag()
 		{
-			var gameToUpdate = new Game { Identifier = TestGameId };
+			var gameToUpdate = new Game { GameId = TestGameId };
 			var tagsToAttribute = new List<Tag> { new Tag() { TagId = TestSecondTagId } };
 
 			var expectedGameIdentifier = TestGameId;
@@ -203,7 +203,7 @@ namespace SteamStore.Tests.Services
 		[Fact]
 		public void UpdateGameWithTags_WhenValid_ShouldCallInsertTag()
 		{
-			var gameToUpdate = new Game { Identifier = TestGameId };
+			var gameToUpdate = new Game { GameId = TestGameId };
 			var tagsToAttribute = new List<Tag> { new Tag() { TagId = TestSecondTagId } };
 
 			var expectedGameIdentifier = TestGameId;
@@ -226,7 +226,7 @@ namespace SteamStore.Tests.Services
 		[Fact]
 		public void GetDeveloperGames_WhenValid_ShouldReturnDeveloperGames()
 		{
-			gameRepositoryMock.Setup(r => r.GetDeveloperGames(testUser.UserIdentifier)).Returns(new List<Game>());
+			gameRepositoryMock.Setup(r => r.GetDeveloperGames(testUser.UserId)).Returns(new List<Game>());
 
 			var foundDeveloperGames = service.GetDeveloperGames();
 
@@ -236,7 +236,7 @@ namespace SteamStore.Tests.Services
 		[Fact]
 		public void GetUnvalidated_WhenValid_ShouldReturnUnvalidatedGames()
 		{
-			gameRepositoryMock.Setup(r => r.GetUnvalidated(testUser.UserIdentifier)).Returns(new List<Game>());
+			gameRepositoryMock.Setup(r => r.GetUnvalidated(testUser.UserId)).Returns(new List<Game>());
 
 			var unvalidatedGames = service.GetUnvalidated();
 
@@ -379,7 +379,7 @@ namespace SteamStore.Tests.Services
 		[Fact]
 		public void DeleteGame_WhenDeletingValidGame_ShouldRemoveFromCollection()
 		{
-			var gameList = new ObservableCollection<Game> { new Game() { Identifier = TestGameId } };
+			var gameList = new ObservableCollection<Game> { new Game() { GameId = TestGameId } };
 			var expectedIdentifier = TestGameId;
 
 			service.DeleteGame(expectedIdentifier, gameList);
@@ -390,8 +390,8 @@ namespace SteamStore.Tests.Services
 		[Fact]
 		public void UpdateGameAndRefreshList_WhenUpdatingValidGame_ShouldUpdateCorrectly()
 		{
-			var existing = new Game { Identifier = TestGameId };
-			var updated = new Game { Identifier = TestGameId, Name = "Updated" };
+			var existing = new Game { GameId = TestGameId };
+			var updated = new Game { GameId = TestGameId, GameTitle = "Updated" };
 			var games = new ObservableCollection<Game> { existing };
 
 			service.UpdateGameAndRefreshList(updated, games);
@@ -402,7 +402,7 @@ namespace SteamStore.Tests.Services
 		[Fact]
 		public void RejectGameAndRemoveFromUnvalidated_WhenRemovingGameFromList_ShouldHaveListEmpty()
 		{
-			var games = new ObservableCollection<Game> { new Game { Identifier = TestGameId } };
+			var games = new ObservableCollection<Game> { new Game { GameId = TestGameId } };
 			var expectedIdentifier = TestGameId;
 
 			service.RejectGameAndRemoveFromUnvalidated(expectedIdentifier, games);
@@ -413,8 +413,8 @@ namespace SteamStore.Tests.Services
 		[Fact]
 		public void IsGameIdInUse_WhenGameIdIsNotInUse_ShouldReturnFalse()
 		{
-			var devGames = new ObservableCollection<Game> { new Game { Identifier = TestGameId } };
-			var unvalidated = new ObservableCollection<Game> { new Game { Identifier = 2 } };
+			var devGames = new ObservableCollection<Game> { new Game { GameId = TestGameId } };
+			var unvalidated = new ObservableCollection<Game> { new Game { GameId = 2 } };
 
 			var expectedThirdIdentifier = 3;
 

--- a/Source/CtrlAltElite.Tests/Services/GameServiceTest.cs
+++ b/Source/CtrlAltElite.Tests/Services/GameServiceTest.cs
@@ -96,9 +96,9 @@ public class GameServiceTest
     [Fact]
     public void SearchGames_WhenCalledWithSearchQuery_ReturnsOnlyMatchingItems()
     {
-        var expectedGame1 = new Game { Name = TEST_GAME_1 };
-        var expectedGame2 = new Game { Name = TEST_GAME_2 };
-        var excludedGame = new Game { Name = TEST_GAME_3 };
+        var expectedGame1 = new Game { GameTitle = TEST_GAME_1 };
+        var expectedGame2 = new Game { GameTitle = TEST_GAME_2 };
+        var excludedGame = new Game { GameTitle = TEST_GAME_3 };
         repoMock.Setup(gameRepository => gameRepository.GetAllGames())
             .Returns(new Collection<Game> { expectedGame1, expectedGame2, excludedGame });
 
@@ -110,9 +110,9 @@ public class GameServiceTest
     [Fact]
     public void SearchGames_WhenCalledWithSearchQueryThatDoesNotMatchAnyItem_ShouldReturnEmptyResult()
     {
-        var excludedGame1 = new Game { Name = TEST_GAME_1 };
-        var excludedGame2 = new Game { Name = TEST_GAME_2 };
-        var excludedGame3 = new Game { Name = TEST_GAME_3 };
+        var excludedGame1 = new Game { GameTitle = TEST_GAME_1 };
+        var excludedGame2 = new Game { GameTitle = TEST_GAME_2 };
+        var excludedGame3 = new Game { GameTitle = TEST_GAME_3 };
         repoMock.Setup(gameRepository => gameRepository.GetAllGames())
             .Returns(new Collection<Game> { excludedGame1, excludedGame2, excludedGame3 });
 
@@ -267,7 +267,7 @@ public class GameServiceTest
     {
         var similarGames = GetSimilarGamesSetUp();
 
-        Assert.DoesNotContain(similarGames, game => game.Identifier == IDENTIFIER_1);
+        Assert.DoesNotContain(similarGames, game => game.GameId == IDENTIFIER_1);
     }
 
     [Fact]
@@ -275,7 +275,7 @@ public class GameServiceTest
     {
         var similarGames = GetSimilarGamesSetUp();
 
-        var identifiers = similarGames.Select(game => game.Identifier).ToList();
+        var identifiers = similarGames.Select(game => game.GameId).ToList();
         Assert.True(identifiers.Count == identifiers.Distinct().Count());
     }
 
@@ -284,11 +284,11 @@ public class GameServiceTest
     {
         var allGames = new Collection<Game>
         {
-            new Game() { Identifier = IDENTIFIER_1, Name = TEST_GAME_1 },
-            new Game() { Identifier = IDENTIFIER_2, Name = TEST_GAME_2 },
-            new Game() { Identifier = IDENTIFIER_3, Name = TEST_GAME_3 },
-            new Game() { Identifier = IDENTIFIER_4, Name = TEST_GAME_4 },
-            new Game() { Identifier = IDENTIFIER_5, Name = TEST_GAME_5 }
+            new Game() { GameId = IDENTIFIER_1, GameTitle = TEST_GAME_1 },
+            new Game() { GameId = IDENTIFIER_2, GameTitle = TEST_GAME_2 },
+            new Game() { GameId = IDENTIFIER_3, GameTitle = TEST_GAME_3 },
+            new Game() { GameId = IDENTIFIER_4, GameTitle = TEST_GAME_4 },
+            new Game() { GameId = IDENTIFIER_5, GameTitle = TEST_GAME_5 }
         };
         repoMock.Setup(r => r.GetAllGames())
             .Returns(allGames);
@@ -309,11 +309,11 @@ public class GameServiceTest
     {
         var allGames = new Collection<Game>
         {
-            new Game() { Identifier = IDENTIFIER_1, Name = TEST_GAME_1 },
-            new Game() { Identifier = IDENTIFIER_2, Name = TEST_GAME_2 },
-            new Game() { Identifier = IDENTIFIER_3, Name = TEST_GAME_3 },
-            new Game() { Identifier = IDENTIFIER_4, Name = TEST_GAME_4 },
-            new Game() { Identifier = IDENTIFIER_5, Name = TEST_GAME_5 }
+            new Game() { GameId = IDENTIFIER_1, GameTitle = TEST_GAME_1 },
+            new Game() { GameId = IDENTIFIER_2, GameTitle = TEST_GAME_2 },
+            new Game() { GameId = IDENTIFIER_3, GameTitle = TEST_GAME_3 },
+            new Game() { GameId = IDENTIFIER_4, GameTitle = TEST_GAME_4 },
+            new Game() { GameId = IDENTIFIER_5, GameTitle = TEST_GAME_5 }
         };
 
         repoMock.Setup(r => r.GetAllGames())

--- a/Source/CtrlAltElite.Tests/Services/PointShopServiceTest.cs
+++ b/Source/CtrlAltElite.Tests/Services/PointShopServiceTest.cs
@@ -33,8 +33,8 @@ namespace SteamStore.Tests.Services
             const float InitialPointsBalance = 999999.99f;
             testUser = new User
             {
-                UserIdentifier = UserID,
-                Name = UserName,
+                UserId = UserID,
+                UserName = UserName,
                 PointsBalance = InitialPointsBalance
             };
 
@@ -45,7 +45,7 @@ namespace SteamStore.Tests.Services
         public void GetCurrentUser_Always_ShouldReturnCurrentUser()
         {
             var user = service.GetCurrentUser();
-            Assert.Equal(testUser.UserIdentifier, user.UserIdentifier);
+            Assert.Equal(testUser.UserId, user.UserId);
         }
 
         [Fact]

--- a/Source/CtrlAltElite.Tests/Services/UserGameServiceTest.cs
+++ b/Source/CtrlAltElite.Tests/Services/UserGameServiceTest.cs
@@ -71,7 +71,7 @@ namespace SteamStore.Tests.Services
         [Fact]
         public void AddGameToWishlist_WhenGameIsAlreadyOwned_ThrowsException()
         {
-            var gameToAdd = new Game { Name = FirstGame };
+            var gameToAdd = new Game { GameTitle = FirstGame };
             mockUserGameRepository.Setup(repository => repository.IsGamePurchased(gameToAdd)).Returns(true);
 
             var exceptionAddGameToWishList = Assert.Throws<Exception>(() => userGameService.AddGameToWishlist(gameToAdd));
@@ -82,7 +82,7 @@ namespace SteamStore.Tests.Services
         [Fact]
         public void AddGameToWishlist_WhenGameIsNotOwned_CallsRepository()
         {
-            var gameToAdd = new Game { Name = SecondGame };
+            var gameToAdd = new Game { GameTitle = SecondGame };
 
             mockUserGameRepository.Setup(repository => repository.IsGamePurchased(gameToAdd)).Returns(false);
 
@@ -94,7 +94,7 @@ namespace SteamStore.Tests.Services
         public void AddGameToWishlist_WhenSqlException_ThrowsException()
         {
             const string ThirdGame = "ThirdGame";
-            var gameToAdd = new Game { Name = ThirdGame };
+            var gameToAdd = new Game { GameTitle = ThirdGame };
 
             mockUserGameRepository.Setup(repository => repository.IsGamePurchased(gameToAdd)).Returns(false);
             mockUserGameRepository.Setup(repository => repository.AddGameToWishlist(gameToAdd)).Throws(new Exception(ErrorStrings.SQLNONQUERYFAILUREINDICATOR));
@@ -106,7 +106,7 @@ namespace SteamStore.Tests.Services
         [Fact]
         public void PurchaseGames_WhenGameIsPurchasedSuccesful_CallsRepository()
         {
-            var gameToPurchase = new Game { Name = FirstGame };
+            var gameToPurchase = new Game { GameTitle = FirstGame };
             var gamesToPurchase = new List<Game> { gameToPurchase };
 
             mockUserGameRepository.SetupSequence(repository => repository.GetUserPointsBalance())
@@ -122,7 +122,7 @@ namespace SteamStore.Tests.Services
         [Fact]
         public void PurchaseGames_WhenGameIsPurchasedSuccesfull_CalculatesPointsCorrectly()
         {
-            var gameToPurchase = new Game { Name = FirstGame };
+            var gameToPurchase = new Game { GameTitle = FirstGame };
             var gamesToPurchase = new List<Game> { gameToPurchase };
 
             mockUserGameRepository.SetupSequence(repository => repository.GetUserPointsBalance())
@@ -138,7 +138,7 @@ namespace SteamStore.Tests.Services
         public void ComputeNumberOfUserGamesForEachTag_WhenTagIsUsedInOneGame_CountIsSetToOne()
         {
             var tagUsed = new Tag { Tag_name = FirstTagName };
-            var gameWithTag = new Game { Name = FirstGame, Tags = new[] { FirstTagName } };
+            var gameWithTag = new Game { GameTitle = FirstGame, Tags = new[] { FirstTagName } };
 
             mockUserGameRepository.Setup(repository => repository.GetAllUserGames()).Returns(new Collection<Game> { gameWithTag });
 
@@ -155,7 +155,7 @@ namespace SteamStore.Tests.Services
             const int NumberOfUsersGamesWithTagNeverUsed = 0;
 
             var tagNotUsed = new Tag { Tag_name = SecondTagName };
-            var gameWithoutTag = new Game { Name = FirstGame, Tags = new[] { FirstTagName } };
+            var gameWithoutTag = new Game { GameTitle = FirstGame, Tags = new[] { FirstTagName } };
 
             mockUserGameRepository.Setup(repository => repository.GetAllUserGames()).Returns(new Collection<Game> { gameWithoutTag });
 
@@ -172,8 +172,8 @@ namespace SteamStore.Tests.Services
             const int NumberOfUsersGamesWithTagUsedMultiple = 2;
 
             var tagUsed = new Tag { Tag_name = FirstTagName };
-            var gameUsingTag1 = new Game { Name = FirstGame, Tags = new[] { FirstTagName } };
-            var gameUsingTag2 = new Game { Name = SecondGame, Tags = new[] { FirstTagName, SecondTagName } };
+            var gameUsingTag1 = new Game { GameTitle = FirstGame, Tags = new[] { FirstTagName } };
+            var gameUsingTag2 = new Game { GameTitle = SecondGame, Tags = new[] { FirstTagName, SecondTagName } };
 
             mockUserGameRepository.Setup(repository => repository.GetAllUserGames()).Returns(new Collection<Game> { gameUsingTag1, gameUsingTag2 });
 
@@ -190,7 +190,7 @@ namespace SteamStore.Tests.Services
             var tagUsed1 = new Tag { Tag_name = FirstTagName };
             var tagUsed2 = new Tag { Tag_name = SecondTagName };
 
-            var multipleTagGame = new Game { Name = FirstGame, Tags = new[] { FirstTagName, SecondTagName } };
+            var multipleTagGame = new Game { GameTitle = FirstGame, Tags = new[] { FirstTagName, SecondTagName } };
 
             mockUserGameRepository.Setup(repository => repository.GetAllUserGames()).Returns(new Collection<Game> { multipleTagGame });
 
@@ -448,8 +448,8 @@ namespace SteamStore.Tests.Services
             const decimal TrendingScoreExpected2 = 1.0m;
             var trendingGames = new Collection<Game>
             {
-                new Game { Name = FirstGame, NumberOfRecentPurchases = RecentPurchasesFirstGame },
-                new Game { Name = SecondGame, NumberOfRecentPurchases = RecentPurchasesSecondGame }
+                new Game { GameTitle = FirstGame, NumberOfRecentPurchases = RecentPurchasesFirstGame },
+                new Game { GameTitle = SecondGame, NumberOfRecentPurchases = RecentPurchasesSecondGame }
             };
 
             userGameService.ComputeTrendingScores(trendingGames);
@@ -465,7 +465,7 @@ namespace SteamStore.Tests.Services
             const decimal TrendingScoreExpected = 1.0m;
             var singleGame = new Collection<Game>
             {
-                new Game { Name = FirstGame, NumberOfRecentPurchases = RecentPurchasesFirstGame }
+                new Game { GameTitle = FirstGame, NumberOfRecentPurchases = RecentPurchasesFirstGame }
             };
 
             userGameService.ComputeTrendingScores(singleGame);
@@ -510,7 +510,7 @@ namespace SteamStore.Tests.Services
 
             var allGames = Enumerable.Range(NumberGenerateGamesNumberMinimum, NumberGenerateGamesNumberMaximum).Select(gameIndex => new Game
             {
-                Name = $"Game{gameIndex}",
+                GameTitle = $"Game{gameIndex}",
                 NumberOfRecentPurchases = gameIndex,
                 Tags = new[] { FirstTagName }
             }).ToList();
@@ -530,15 +530,15 @@ namespace SteamStore.Tests.Services
             const int First = 0;
             var wishlistGames = new Collection<Game>
             {
-                new Game { Name = FirstGame },
-                new Game { Name = SecondGame }
+                new Game { GameTitle = FirstGame },
+                new Game { GameTitle = SecondGame }
             };
 
             mockUserGameRepository.Setup(repository => repository.GetWishlistGames()).Returns(wishlistGames);
 
             var matchedGames = userGameService.SearchWishListByName(FirstGame);
             Assert.Single(matchedGames);
-            Assert.Equal(FirstGame, matchedGames[First].Name);
+            Assert.Equal(FirstGame, matchedGames[First].GameTitle);
         }
 
         [Fact]
@@ -547,8 +547,8 @@ namespace SteamStore.Tests.Services
             const string SearchWishListString = "Game";
             var wishlistGames = new Collection<Game>
             {
-                new Game { Name = FirstGame },
-                new Game { Name = SecondGame }
+                new Game { GameTitle = FirstGame },
+                new Game { GameTitle = SecondGame }
             };
 
             mockUserGameRepository.Setup(repository => repository.GetWishlistGames()).Returns(wishlistGames);
@@ -648,8 +648,8 @@ namespace SteamStore.Tests.Services
             const int Second = 1;
             var gamesList = new Collection<Game>
             {
-                new Game { Name = FirstGame, Rating = RatingMedium },
-                new Game { Name = SecondGame, Rating = RatingHigh }
+                new Game { GameTitle = FirstGame, Rating = RatingMedium },
+                new Game { GameTitle = SecondGame, Rating = RatingHigh }
             };
 
             mockUserGameRepository.Setup(repository => repository.GetWishlistGames()).Returns(gamesList);
@@ -666,8 +666,8 @@ namespace SteamStore.Tests.Services
             const int Second = 1;
             var gamesList = new Collection<Game>
             {
-                new Game { Name = FirstGame, Rating = RatingMedium },
-                new Game { Name = SecondGame, Rating = RatingHigh }
+                new Game { GameTitle = FirstGame, Rating = RatingMedium },
+                new Game { GameTitle = SecondGame, Rating = RatingHigh }
             };
 
             mockUserGameRepository.Setup(repository => repository.GetWishlistGames()).Returns(gamesList);
@@ -684,8 +684,8 @@ namespace SteamStore.Tests.Services
             const int Second = 1;
             var gamesList = new Collection<Game>
             {
-                new Game { Name = FirstGame, Price = PriceHigh },
-                new Game { Name = SecondGame, Price = PriceLow }
+                new Game { GameTitle = FirstGame, Price = PriceHigh },
+                new Game { GameTitle = SecondGame, Price = PriceLow }
             };
 
             mockUserGameRepository.Setup(repository => repository.GetWishlistGames()).Returns(gamesList);
@@ -700,8 +700,8 @@ namespace SteamStore.Tests.Services
         {
             var gamesList = new Collection<Game>
             {
-                new Game { Name = FirstGame, Price = PriceHigh },
-                new Game { Name = SecondGame, Price = PriceLow }
+                new Game { GameTitle = FirstGame, Price = PriceHigh },
+                new Game { GameTitle = SecondGame, Price = PriceLow }
             };
 
             mockUserGameRepository.Setup(repository => repository.GetWishlistGames()).Returns(gamesList);
@@ -716,8 +716,8 @@ namespace SteamStore.Tests.Services
         {
             var gamesList = new Collection<Game>
             {
-                new Game { Name = FirstGame, Discount = DiscountHigh },
-                new Game { Name = SecondGame, Discount = DiscountLow }
+                new Game { GameTitle = FirstGame, Discount = DiscountHigh },
+                new Game { GameTitle = SecondGame, Discount = DiscountLow }
             };
 
             mockUserGameRepository.Setup(repository => repository.GetWishlistGames()).Returns(gamesList);
@@ -732,8 +732,8 @@ namespace SteamStore.Tests.Services
         {
             var gamesList = new Collection<Game>
             {
-                new Game { Name = FirstGame, Discount = DiscountHigh },
-                new Game { Name = SecondGame, Discount = DiscountLow }
+                new Game { GameTitle = FirstGame, Discount = DiscountHigh },
+                new Game { GameTitle = SecondGame, Discount = DiscountLow }
             };
 
             mockUserGameRepository.Setup(repository => repository.GetWishlistGames()).Returns(gamesList);

--- a/Source/CtrlAltElite.Tests/TestUtils/GameTestUtils.cs
+++ b/Source/CtrlAltElite.Tests/TestUtils/GameTestUtils.cs
@@ -28,9 +28,9 @@ public static class GameTestUtils
     {
         return new Game
         {
-            Identifier = (int)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
-            Name = CommonTestUtils.RandomName(NAME_SIZE),
-            Description = CommonTestUtils.RandomName(DESCRIPTION_SIZE),
+            GameId = (int)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            GameTitle = CommonTestUtils.RandomName(NAME_SIZE),
+            GameDescription = CommonTestUtils.RandomName(DESCRIPTION_SIZE),
             ImagePath = CommonTestUtils.RandomPath(),
             Price = CommonTestUtils.RandomNumber(STARTING_PRICE, MAX_PRICE, PRICE_DECIMAL_COUNT),
             TrailerPath = CommonTestUtils.RandomPath(),

--- a/Source/CtrlAltElite/Constants/SqlConstants.cs
+++ b/Source/CtrlAltElite/Constants/SqlConstants.cs
@@ -14,7 +14,7 @@ namespace SteamStore.Constants
         // Column Names
         public const string GAMEIDCOLUMN = "game_id";
         public const string NAMECOLUMN = "name";
-        public const string DESCRIPTIONCOLUMN = "Description";
+        public const string DESCRIPTIONCOLUMN = "GameDescription";
         public const string IMAGEURLCOLUMN = "image_url";
         public const string PRICECOLUMN = "price";
         public const string RatingColumn = "rating";
@@ -97,8 +97,8 @@ namespace SteamStore.Constants
         public const string QueryResultColumn = "Result";
 
         public const string ItemIdColumnWithCapitalLetter = "ItemId";
-        public const string NameIdColumnWithCapitalLetter = "Name";
-        public const string DescriptionIdColumnWithCapitalLetter = "Description";
+        public const string NameIdColumnWithCapitalLetter = "GameTitle";
+        public const string DescriptionIdColumnWithCapitalLetter = "GameDescription";
         public const string ImagePathColumnWithCapitalLetter = "ImagePath";
         public const string PointPriceColumnWithCapitalLeter = "PointPrice";
         public const string ItemTypeColumnWithCapitalLetter = "ItemType";

--- a/Source/CtrlAltElite/Models/Game.cs
+++ b/Source/CtrlAltElite/Models/Game.cs
@@ -14,11 +14,11 @@ public class Game
     {
     }
 
-    public int Identifier { get; set; }
+    public int GameId { get; set; }
 
-    public string Name { get; set; }
+    public string GameTitle { get; set; }
 
-    public string Description { get; set; }
+    public string GameDescription { get; set; }
 
     public string ImagePath { get; set; }
 

--- a/Source/CtrlAltElite/Models/User.cs
+++ b/Source/CtrlAltElite/Models/User.cs
@@ -10,8 +10,8 @@ public class User
 
     public User(int userIdentifier, string name, string email, float walletBalance, float pointsBalance, Role userRole)
     {
-        this.UserIdentifier = userIdentifier;
-        this.Name = name;
+        this.UserId = userIdentifier;
+        this.UserName = name;
         this.Email = email;
         this.WalletBalance = walletBalance;
         this.PointsBalance = pointsBalance;
@@ -24,9 +24,9 @@ public class User
         User,
     }
 
-    public int UserIdentifier { get; set; }
+    public int UserId { get; set; }
 
-    public string Name { get; set; }
+    public string UserName { get; set; }
 
     public string Email { get; set; }
 

--- a/Source/CtrlAltElite/Pages/DeveloperModePage.xaml.cs
+++ b/Source/CtrlAltElite/Pages/DeveloperModePage.xaml.cs
@@ -318,10 +318,10 @@ namespace SteamStore.Pages
 
         private void PopulateEditForm(Game game)
         {
-            this.EditGameId.Text = game.Identifier.ToString();
+            this.EditGameId.Text = game.GameId.ToString();
             this.EditGameId.IsEnabled = false;
-            this.EditGameName.Text = game.Name;
-            this.EditGameDescription.Text = game.Description;
+            this.EditGameName.Text = game.GameTitle;
+            this.EditGameDescription.Text = game.GameDescription;
             this.EditGamePrice.Text = game.Price.ToString();
             this.EditGameImageUrl.Text = game.ImagePath;
             this.EditGameplayUrl.Text = game.GameplayPath ?? string.Empty;
@@ -339,7 +339,7 @@ namespace SteamStore.Pages
             try
             {
                 var availableTags = this.EditGameTagList.Items.Cast<object>().OfType<Tag>().ToList(); // Safe cast
-                var matchingTags = this.viewModel.GetMatchingTags(game.Identifier, availableTags);
+                var matchingTags = this.viewModel.GetMatchingTags(game.GameId, availableTags);
 
                 foreach (Tag tag in matchingTags)
                 {

--- a/Source/CtrlAltElite/Pages/GamePage.xaml.cs
+++ b/Source/CtrlAltElite/Pages/GamePage.xaml.cs
@@ -58,12 +58,12 @@ namespace SteamStore.Pages
                     return;
                 }
 
-                this.GameTitle.Text = this.viewModel.Game.Name;
+                this.GameTitle.Text = this.viewModel.Game.GameTitle;
                 this.GamePrice.Text = this.GamePrice.Text = this.viewModel.FormattedPrice;
 
-                this.GameDescription.Text = this.viewModel.Game.Description;
+                this.GameDescription.Text = this.viewModel.Game.GameDescription;
 
-                this.GameDeveloper.Text = LabelStrings.DEVELOPERPREFIX + this.viewModel.Game.Name;
+                this.GameDeveloper.Text = LabelStrings.DEVELOPERPREFIX + this.viewModel.Game.GameTitle;
 
                 if (!string.IsNullOrEmpty(this.viewModel.Game.ImagePath))
                 {
@@ -175,7 +175,7 @@ namespace SteamStore.Pages
                 }
             }
 
-            title.Text = game.Name;
+            title.Text = game.GameTitle;
             rating.Text = string.Format(LabelStrings.RATINGFORMAT, game.Rating);
         }
 
@@ -189,7 +189,7 @@ namespace SteamStore.Pages
             catch (Exception exception)
             {
                 this.NotificationTip.Title = NotificationStrings.AddToCartErrorTitle;
-                this.NotificationTip.Subtitle = string.Format(NotificationStrings.AddToCartErrorMessage, this.viewModel.Game.Name) + SpaceString + exception.Message;
+                this.NotificationTip.Subtitle = string.Format(NotificationStrings.AddToCartErrorMessage, this.viewModel.Game.GameTitle) + SpaceString + exception.Message;
                 this.NotificationTip.IsOpen = true;
             }
         }
@@ -197,7 +197,7 @@ namespace SteamStore.Pages
         private void ShowSuccessNotificationForBuy()
         {
             this.NotificationTip.Title = NotificationStrings.AddToCartSuccessTitle;
-            this.NotificationTip.Subtitle = string.Format(NotificationStrings.AddToCartSuccessMessage, this.viewModel.Game.Name);
+            this.NotificationTip.Subtitle = string.Format(NotificationStrings.AddToCartSuccessMessage, this.viewModel.Game.GameTitle);
             this.NotificationTip.IsOpen = true;
         }
 
@@ -207,7 +207,7 @@ namespace SteamStore.Pages
             {
                 this.viewModel.AddToWishlist();
                 this.NotificationTip.Title = NotificationStrings.AddToWishlistSuccessTitle;
-                this.NotificationTip.Subtitle = string.Format(NotificationStrings.AddToWishlistSuccessMessage, this.viewModel.Game.Name);
+                this.NotificationTip.Subtitle = string.Format(NotificationStrings.AddToWishlistSuccessMessage, this.viewModel.Game.GameTitle);
                 this.NotificationTip.IsOpen = true;
             }
             catch (Exception exception)
@@ -216,7 +216,7 @@ namespace SteamStore.Pages
                 string errorMessage = exception.Message;
                 if (errorMessage.Contains(ErrorStrings.SQLNONQUERYFAILUREINDICATOR))
                 {
-                    errorMessage = string.Format(ErrorStrings.ADDTOWISHLISTALREADYEXISTSMESSAGE, this.viewModel.Game.Name);
+                    errorMessage = string.Format(ErrorStrings.ADDTOWISHLISTALREADYEXISTSMESSAGE, this.viewModel.Game.GameTitle);
                 }
 
                 this.NotificationTip.Subtitle = errorMessage;

--- a/Source/CtrlAltElite/Repositories/CartRepository.cs
+++ b/Source/CtrlAltElite/Repositories/CartRepository.cs
@@ -30,7 +30,7 @@ public class CartRepository : ICartRepository
     {
         SqlParameter[] userIdParameters = new SqlParameter[]
         {
-            new SqlParameter(UserIdColumn, this.user.UserIdentifier),
+            new SqlParameter(UserIdColumn, this.user.UserId),
         };
 
         var allCartGames = this.dataLink.ExecuteReader(SqlConstants.GetAllCartGamesProcedure, userIdParameters);
@@ -42,9 +42,9 @@ public class CartRepository : ICartRepository
             {
                 Game game = new Game
                 {
-                    Identifier = (int)row[SqlConstants.GAMEIDCOLUMN],
-                    Name = (string)row[SqlConstants.NAMECOLUMN],
-                    Description = (string)row[SqlConstants.DESCRIPTIONCOLUMN],
+                    GameId = (int)row[SqlConstants.GAMEIDCOLUMN],
+                    GameTitle = (string)row[SqlConstants.NAMECOLUMN],
+                    GameDescription = (string)row[SqlConstants.DESCRIPTIONCOLUMN],
                     ImagePath = (string)row[SqlConstants.IMAGEURLCOLUMN],
                     Price = Convert.ToDecimal(row[SqlConstants.PRICECOLUMN]),
                     Status = ApprovedStatus,
@@ -60,8 +60,8 @@ public class CartRepository : ICartRepository
     {
         SqlParameter[] cartParameters = new SqlParameter[]
         {
-            new SqlParameter(UserIdColumn, this.user.UserIdentifier),
-            new SqlParameter(GameIdColumn, game.Identifier),
+            new SqlParameter(UserIdColumn, this.user.UserId),
+            new SqlParameter(GameIdColumn, game.GameId),
         };
 
         try
@@ -78,8 +78,8 @@ public class CartRepository : ICartRepository
     {
         SqlParameter[] cartRemovalParameters = new SqlParameter[]
         {
-            new SqlParameter(UserIdColumn, this.user.UserIdentifier),
-            new SqlParameter(GameIdColumn, game.Identifier),
+            new SqlParameter(UserIdColumn, this.user.UserId),
+            new SqlParameter(GameIdColumn, game.GameId),
         };
 
         try

--- a/Source/CtrlAltElite/Repositories/GameRepository.cs
+++ b/Source/CtrlAltElite/Repositories/GameRepository.cs
@@ -47,10 +47,10 @@ public class GameRepository : IGameRepository
         {
             var game = new Game
             {
-                Identifier = (int)row[SqlConstants.GameIdColumn],
-                Name = (string)row[SqlConstants.GameNameColumn],
+                GameId = (int)row[SqlConstants.GameIdColumn],
+                GameTitle = (string)row[SqlConstants.GameNameColumn],
                 Price = Convert.ToDecimal(row[SqlConstants.GamePriceColumn]),
-                Description = (string)row[SqlConstants.GameDescriptionColumn],
+                GameDescription = (string)row[SqlConstants.GameDescriptionColumn],
                 ImagePath = (string)row[SqlConstants.ImageUrlColumn],
                 TrailerPath = (string)row[SqlConstants.TrailerUrlColumn],
                 GameplayPath = (string)row[SqlConstants.GameplayUrlColumn],
@@ -104,10 +104,10 @@ public class GameRepository : IGameRepository
         return (from DataRow row in gamesForCurrentDeveloper.Rows
             select new Game
             {
-                Identifier = (int)row[SqlConstants.GameIdColumn],
-                Name = (string)row[SqlConstants.GameNameColumn],
+                GameId = (int)row[SqlConstants.GameIdColumn],
+                GameTitle = (string)row[SqlConstants.GameNameColumn],
                 Price = Convert.ToDecimal(row[SqlConstants.GamePriceColumn]),
-                Description = (string)row[SqlConstants.GameDescriptionColumn],
+                GameDescription = (string)row[SqlConstants.GameDescriptionColumn],
                 ImagePath = (string)row[SqlConstants.ImageUrlColumn],
                 TrailerPath = (string)row[SqlConstants.TrailerUrlColumn],
                 GameplayPath = (string)row[SqlConstants.GameplayUrlColumn],
@@ -124,9 +124,9 @@ public class GameRepository : IGameRepository
         SqlParameter[] updateGameParameters =
         {
             new (SqlConstants.GameIdParameter, gameId),
-            new (SqlConstants.NameParameter, game.Name),
+            new (SqlConstants.NameParameter, game.GameTitle),
             new (SqlConstants.PriceParameter, game.Price),
-            new (SqlConstants.DescriptionParameter, game.Description),
+            new (SqlConstants.DescriptionParameter, game.GameDescription),
             new (SqlConstants.ImageUrlParameter, game.ImagePath),
             new (SqlConstants.TrailerUrlParameter, game.TrailerPath),
             new (SqlConstants.GameplayUrlParameter, game.GameplayPath),
@@ -213,11 +213,11 @@ public class GameRepository : IGameRepository
     {
         var gameParameters = new SqlParameter[]
         {
-            new (SqlConstants.GameIdParameter, game.Identifier),
-            new (SqlConstants.NameParameter, game.Name),
+            new (SqlConstants.GameIdParameter, game.GameId),
+            new (SqlConstants.NameParameter, game.GameTitle),
             new (SqlConstants.PriceParameter, game.Price),
             new (SqlConstants.PublisherIdParameter, game.PublisherIdentifier),
-            new (SqlConstants.DescriptionParameter, game.Description),
+            new (SqlConstants.DescriptionParameter, game.GameDescription),
             new (SqlConstants.ImageUrlParameter, game.ImagePath),
             new (SqlConstants.TrailerUrlParameter, game.TrailerPath ?? string.Empty),
             new (SqlConstants.GameplayUrlParameter, game.GameplayPath ?? string.Empty),
@@ -262,10 +262,10 @@ public class GameRepository : IGameRepository
 
             var game = new Game
             {
-                Identifier = gameId,
+                GameId = gameId,
                 PublisherIdentifier = (int)row[SqlConstants.PublisherIdColumn],
-                Name = (string)row[SqlConstants.GameNameColumn],
-                Description = (string)row[SqlConstants.GameDescriptionColumn],
+                GameTitle = (string)row[SqlConstants.GameNameColumn],
+                GameDescription = (string)row[SqlConstants.GameDescriptionColumn],
                 ImagePath = (string)row[SqlConstants.ImageUrlColumn],
                 TrailerPath = (string)row[SqlConstants.TrailerUrlColumn],
                 GameplayPath = (string)row[SqlConstants.GameplayUrlColumn],

--- a/Source/CtrlAltElite/Repositories/PointShopRepository.cs
+++ b/Source/CtrlAltElite/Repositories/PointShopRepository.cs
@@ -67,7 +67,7 @@ namespace SteamStore.Repositories
             {
                 SqlParameter[] userParameters = new SqlParameter[]
                 {
-                    new SqlParameter(SqlConstants.UserIdParameterWithCapitalLetter, this.user.UserIdentifier),
+                    new SqlParameter(SqlConstants.UserIdParameterWithCapitalLetter, this.user.UserId),
                 };
 
                 DataTable result = this.data.ExecuteReader(SqlConstants.GetUserPointShopItemsProcedure, userParameters);
@@ -116,7 +116,7 @@ namespace SteamStore.Repositories
             {
                 SqlParameter[] pointShopPurchaseParameters = new SqlParameter[]
                 {
-                    new SqlParameter(SqlConstants.UserIdParameterWithCapitalLetter, this.user.UserIdentifier),
+                    new SqlParameter(SqlConstants.UserIdParameterWithCapitalLetter, this.user.UserId),
                     new SqlParameter(SqlConstants.ItemIdParameter, item.ItemIdentifier),
                 };
 
@@ -148,7 +148,7 @@ namespace SteamStore.Repositories
             {
                 SqlParameter[] activateItemParameters = new SqlParameter[]
                 {
-                    new SqlParameter(SqlConstants.UserIdParameterWithCapitalLetter, this.user.UserIdentifier),
+                    new SqlParameter(SqlConstants.UserIdParameterWithCapitalLetter, this.user.UserId),
                     new SqlParameter(SqlConstants.ItemIdParameter, item.ItemIdentifier),
                 };
 
@@ -176,7 +176,7 @@ namespace SteamStore.Repositories
             {
                 SqlParameter[] deactivateItemParameters = new SqlParameter[]
                 {
-                    new SqlParameter(SqlConstants.UserIdParameterWithCapitalLetter, this.user.UserIdentifier),
+                    new SqlParameter(SqlConstants.UserIdParameterWithCapitalLetter, this.user.UserId),
                     new SqlParameter(SqlConstants.ItemIdParameter, item.ItemIdentifier),
                 };
 
@@ -194,7 +194,7 @@ namespace SteamStore.Repositories
             {
                 SqlParameter[] userPointBalanceParametrs = new SqlParameter[]
                 {
-                    new SqlParameter(SqlConstants.UserIdParameterWithCapitalLetter, this.user.UserIdentifier),
+                    new SqlParameter(SqlConstants.UserIdParameterWithCapitalLetter, this.user.UserId),
                     new SqlParameter(SqlConstants.PointBalanceParameter, this.user.PointsBalance),
                 };
 
@@ -217,7 +217,7 @@ namespace SteamStore.Repositories
             {
                 SqlParameter[] parameters = new SqlParameter[]
                 {
-                    new SqlParameter(SqlConstants.UserIdParameterWithCapitalLetter, this.user.UserIdentifier),
+                    new SqlParameter(SqlConstants.UserIdParameterWithCapitalLetter, this.user.UserId),
                 };
                 this.data.ExecuteNonQuery(SqlConstants.ResetUserInventoryToDefault, parameters);
             }

--- a/Source/CtrlAltElite/Repositories/UserGameRepository.cs
+++ b/Source/CtrlAltElite/Repositories/UserGameRepository.cs
@@ -37,8 +37,8 @@ public class UserGameRepository : IUserGameRepository
     {
         SqlParameter[] gamePurchasedParameters = new SqlParameter[]
         {
-            new SqlParameter(SqlConstants.GameIdParameter, game.Identifier),
-            new SqlParameter(SqlConstants.UserIdParameter, this.user.UserIdentifier),
+            new SqlParameter(SqlConstants.GameIdParameter, game.GameId),
+            new SqlParameter(SqlConstants.UserIdParameter, this.user.UserId),
         };
         try
         {
@@ -54,8 +54,8 @@ public class UserGameRepository : IUserGameRepository
     {
         SqlParameter[] removeGamesParameters = new SqlParameter[]
         {
-            new SqlParameter(SqlConstants.UserIdParameter, this.user.UserIdentifier),
-            new SqlParameter(SqlConstants.GameIdParameter, game.Identifier),
+            new SqlParameter(SqlConstants.UserIdParameter, this.user.UserId),
+            new SqlParameter(SqlConstants.GameIdParameter, game.GameId),
         };
 
         try
@@ -72,8 +72,8 @@ public class UserGameRepository : IUserGameRepository
     {
         SqlParameter[] purchaseGameParameters = new SqlParameter[]
         {
-            new SqlParameter(SqlConstants.UserIdParameter, this.user.UserIdentifier),
-            new SqlParameter(SqlConstants.GameIdParameter, game.Identifier),
+            new SqlParameter(SqlConstants.UserIdParameter, this.user.UserId),
+            new SqlParameter(SqlConstants.GameIdParameter, game.GameId),
         };
 
         try
@@ -99,8 +99,8 @@ public class UserGameRepository : IUserGameRepository
     {
         SqlParameter[] addGameToWishlistParameters = new SqlParameter[]
         {
-            new SqlParameter(SqlConstants.UserIdParameter, this.user.UserIdentifier),
-            new SqlParameter(SqlConstants.GameIdParameter, game.Identifier),
+            new SqlParameter(SqlConstants.UserIdParameter, this.user.UserId),
+            new SqlParameter(SqlConstants.GameIdParameter, game.GameId),
         };
 
         try
@@ -153,7 +153,7 @@ public class UserGameRepository : IUserGameRepository
     {
         SqlParameter[] allUsersParameters = new SqlParameter[]
         {
-            new SqlParameter(SqlConstants.UserIdentifierParameter, this.user.UserIdentifier),
+            new SqlParameter(SqlConstants.UserIdentifierParameter, this.user.UserId),
         };
 
         var allUserGames = this.dataLink.ExecuteReader(SqlConstants.GetUserGamesProcedure, allUsersParameters);
@@ -165,9 +165,9 @@ public class UserGameRepository : IUserGameRepository
             {
                 Game game = new Game
                 {
-                    Identifier = (int)row[SqlConstants.GameIdColumn],
-                    Name = (string)row[SqlConstants.GameNameColumn],
-                    Description = (string)row[SqlConstants.DescriptionIdColumnWithCapitalLetter],
+                    GameId = (int)row[SqlConstants.GameIdColumn],
+                    GameTitle = (string)row[SqlConstants.GameNameColumn],
+                    GameDescription = (string)row[SqlConstants.DescriptionIdColumnWithCapitalLetter],
                     ImagePath = (string)row[SqlConstants.ImageUrlColumn],
                     Price = Convert.ToDecimal(row[SqlConstants.GamePriceColumn]),
                     MinimumRequirements = (string)row[SqlConstants.MinimumRequirementsColumn],
@@ -196,7 +196,7 @@ public class UserGameRepository : IUserGameRepository
             // Update in database
             SqlParameter[] addingPointsParameter = new SqlParameter[]
             {
-                new SqlParameter(SqlConstants.UserIdParameterWithCapitalLetter, this.user.UserIdentifier),
+                new SqlParameter(SqlConstants.UserIdParameterWithCapitalLetter, this.user.UserId),
                 new SqlParameter(SqlConstants.PointBalanceParameter, this.user.PointsBalance),
             };
 
@@ -218,7 +218,7 @@ public class UserGameRepository : IUserGameRepository
     {
         SqlParameter[] wishlistGamesParameters = new SqlParameter[]
         {
-            new SqlParameter(SqlConstants.UserIdParameter, this.user.UserIdentifier),
+            new SqlParameter(SqlConstants.UserIdParameter, this.user.UserId),
         };
 
         var wishlistGamesData = this.dataLink.ExecuteReader(SqlConstants.GetWishlistGamesProcedure, wishlistGamesParameters);
@@ -230,9 +230,9 @@ public class UserGameRepository : IUserGameRepository
             {
                 Game game = new Game
                 {
-                    Identifier = (int)row[SqlConstants.GameIdColumn],
-                    Name = (string)row[SqlConstants.GameNameColumn],
-                    Description = (string)row[SqlConstants.DescriptionIdColumnWithCapitalLetter],
+                    GameId = (int)row[SqlConstants.GameIdColumn],
+                    GameTitle = (string)row[SqlConstants.GameNameColumn],
+                    GameDescription = (string)row[SqlConstants.DescriptionIdColumnWithCapitalLetter],
                     ImagePath = (string)row[SqlConstants.ImageUrlColumn],
                     Price = Convert.ToDecimal(row[SqlConstants.GamePriceColumn]),
                     MinimumRequirements = (string)row[SqlConstants.MinimumRequirementsColumn],

--- a/Source/CtrlAltElite/Services/DeveloperService.cs
+++ b/Source/CtrlAltElite/Services/DeveloperService.cs
@@ -62,13 +62,13 @@ public class DeveloperService : IDeveloperService
             throw new Exception(ExceptionMessages.NoTagsSelected);
         }
 
-       // var game = new Game(gameId, name,price, description, imageUrl, gameplayUrl, trailerUrl, minReq, recReq, "Pending", discount);
+       // var game = new Game(GameId, name,price, description, imageUrl, gameplayUrl, trailerUrl, minReq, recReq, "Pending", discount);
         var game = new Game
         {
-            Identifier = gameId,
-            Name = name,
+            GameId = gameId,
+            GameTitle = name,
             Price = price,
-            Description = description,
+            GameDescription = description,
             ImagePath = imageUrl,
             GameplayPath = gameplayUrl,
             TrailerPath = trailerUrl,
@@ -84,7 +84,7 @@ public class DeveloperService : IDeveloperService
     {
         foreach (Game game in gameList)
         {
-            if (game.Identifier == gameId)
+            if (game.GameId == gameId)
             {
                 return game;
             }
@@ -95,7 +95,7 @@ public class DeveloperService : IDeveloperService
 
     public void CreateGame(Game game)
     {
-        game.PublisherIdentifier = this.User.UserIdentifier;
+        game.PublisherIdentifier = this.User.UserId;
         this.GameRepository.CreateGame(game);
     }
 
@@ -107,29 +107,29 @@ public class DeveloperService : IDeveloperService
         {
             foreach (var tag in selectedTags)
             {
-                this.InsertGameTag(game.Identifier, tag.TagId);
+                this.InsertGameTag(game.GameId, tag.TagId);
             }
         }
     }
 
     public void UpdateGame(Game game)
     {
-        game.PublisherIdentifier = this.User.UserIdentifier;
-        this.GameRepository.UpdateGame(game.Identifier, game);
+        game.PublisherIdentifier = this.User.UserId;
+        this.GameRepository.UpdateGame(game.GameId, game);
     }
 
     public void UpdateGameWithTags(Game game, IList<Tag> selectedTags)
     {
-        game.PublisherIdentifier = this.User.UserIdentifier;
-        this.GameRepository.UpdateGame(game.Identifier, game);
+        game.PublisherIdentifier = this.User.UserId;
+        this.GameRepository.UpdateGame(game.GameId, game);
         try
         {
-            this.DeleteGameTags(game.Identifier);
+            this.DeleteGameTags(game.GameId);
             if (selectedTags != null && selectedTags.Count > EmptyListLength)
             {
                 foreach (var tag in selectedTags)
                 {
-                    this.InsertGameTag(game.Identifier, tag.TagId);
+                    this.InsertGameTag(game.GameId, tag.TagId);
                 }
             }
         }
@@ -153,12 +153,12 @@ public class DeveloperService : IDeveloperService
 
     public List<Game> GetDeveloperGames()
     {
-        return this.GameRepository.GetDeveloperGames(this.User.UserIdentifier);
+        return this.GameRepository.GetDeveloperGames(this.User.UserId);
     }
 
     public List<Game> GetUnvalidated()
     {
-        return this.GameRepository.GetUnvalidated(this.User.UserIdentifier);
+        return this.GameRepository.GetUnvalidated(this.User.UserId);
     }
 
     public void RejectGame(int gameId)
@@ -215,7 +215,7 @@ public class DeveloperService : IDeveloperService
     {
         var game = this.ValidateInputForAddingAGame(gameIdText, name, priceText, description, imageUrl, trailerUrl, gameplayUrl, minimumRequirement, reccommendedRequirement, discountText, selectedTags);
 
-        if (this.IsGameIdInUse(game.Identifier))
+        if (this.IsGameIdInUse(game.GameId))
         {
             throw new Exception(ExceptionMessages.IdAlreadyInUse);
         }
@@ -230,7 +230,7 @@ public class DeveloperService : IDeveloperService
         Game gameToRemove = null;
         foreach (var game in developerGames)
         {
-            if (game.Identifier == gameId)
+            if (game.GameId == gameId)
             {
                 gameToRemove = game;
                 break;
@@ -251,7 +251,7 @@ public class DeveloperService : IDeveloperService
         Game existing = null;
         foreach (var gameInDeveloperGames in developerGames)
         {
-            if (gameInDeveloperGames.Identifier == game.Identifier)
+            if (gameInDeveloperGames.GameId == game.GameId)
             {
                 existing = gameInDeveloperGames;
                 break;
@@ -274,7 +274,7 @@ public class DeveloperService : IDeveloperService
         Game gameToRemove = null;
         foreach (var game in unvalidatedGames)
         {
-            if (game.Identifier == gameId)
+            if (game.GameId == gameId)
             {
                 gameToRemove = game;
                 break;
@@ -291,7 +291,7 @@ public class DeveloperService : IDeveloperService
     {
         foreach (var game in developerGames)
         {
-            if (game.Identifier == gameId)
+            if (game.GameId == gameId)
             {
                 return true;
             }
@@ -299,7 +299,7 @@ public class DeveloperService : IDeveloperService
 
         foreach (var game in unvalidatedGames)
         {
-            if (game.Identifier == gameId)
+            if (game.GameId == gameId)
             {
                 return true;
             }

--- a/Source/CtrlAltElite/Services/GameService.cs
+++ b/Source/CtrlAltElite/Services/GameService.cs
@@ -60,7 +60,7 @@ public class GameService : IGameService
 
         foreach (var game in allGames)
         {
-            if (game.Name.ToLower().Contains(searchQuery.ToLower()))
+            if (game.GameTitle.ToLower().Contains(searchQuery.ToLower()))
             {
                 foundGames.Add(game);
             }
@@ -156,7 +156,7 @@ public class GameService : IGameService
         // Filter games with different identifiers
         foreach (var game in allGames)
         {
-            if (game.Identifier != gameId)
+            if (game.GameId != gameId)
             {
                 similarGames.Add(game);
             }
@@ -180,7 +180,7 @@ public class GameService : IGameService
         var allGames = this.GetAllGames();
         for (int currentIndexOfGAmeInList = startingValueOfIndex; currentIndexOfGAmeInList < allGames.Count; currentIndexOfGAmeInList++)
         {
-            if (allGames[currentIndexOfGAmeInList].Identifier == gameId)
+            if (allGames[currentIndexOfGAmeInList].GameId == gameId)
             {
                 return allGames[currentIndexOfGAmeInList];
             }

--- a/Source/CtrlAltElite/Services/UserGameService.cs
+++ b/Source/CtrlAltElite/Services/UserGameService.cs
@@ -50,7 +50,7 @@ public class UserGameService : IUserGameService
             // Check if game is already purchased
             if (this.IsGamePurchased(game))
             {
-                throw new Exception(string.Format(ExceptionMessages.GameAlreadyOwned, game.Name));
+                throw new Exception(string.Format(ExceptionMessages.GameAlreadyOwned, game.GameTitle));
             }
 
             this.UserGameRepository.AddGameToWishlist(game);
@@ -61,7 +61,7 @@ public class UserGameService : IUserGameService
             string message = exception.Message;
             if (message.Contains("ExecuteNonQuery"))
             {
-                message = string.Format(ExceptionMessages.GameAlreadyInWishlist, game.Name);
+                message = string.Format(ExceptionMessages.GameAlreadyInWishlist, game.GameTitle);
             }
 
             throw new Exception(message);
@@ -223,7 +223,7 @@ public class UserGameService : IUserGameService
 
         foreach (Game game in allWishListGames)
         {
-            if (game.Name != null && game.Name.ToLower().Contains(searchText.ToLower()))
+            if (game.GameTitle != null && game.GameTitle.ToLower().Contains(searchText.ToLower()))
             {
                 matchingGames.Add(game);
             }
@@ -371,11 +371,11 @@ public class UserGameService : IUserGameService
 
     private int CompareByNameAscending(Game firstGame, Game secondGame)
     {
-        return string.Compare(firstGame.Name, secondGame.Name, StringComparison.OrdinalIgnoreCase);
+        return string.Compare(firstGame.GameTitle, secondGame.GameTitle, StringComparison.OrdinalIgnoreCase);
     }
 
     private int CompareByNameDescending(Game firstGame, Game secondGame)
     {
-        return string.Compare(secondGame.Name, firstGame.Name, StringComparison.OrdinalIgnoreCase);
+        return string.Compare(secondGame.GameTitle, firstGame.GameTitle, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/Source/CtrlAltElite/ViewModels/GamePageViewModel.cs
+++ b/Source/CtrlAltElite/ViewModels/GamePageViewModel.cs
@@ -207,7 +207,7 @@ public class GamePageViewModel : INotifyPropertyChanged
             return;
         }
 
-        var similarGames = this.gameService.GetSimilarGames(this.Game.Identifier);
+        var similarGames = this.gameService.GetSimilarGames(this.Game.GameId);
         this.SimilarGames = new ObservableCollection<Game>(similarGames.Take(MaxSimilarGamesToDisplay));
     }
 }

--- a/Source/CtrlAltElite/ViewModels/WishListViewModel.cs
+++ b/Source/CtrlAltElite/ViewModels/WishListViewModel.cs
@@ -193,7 +193,7 @@ namespace SteamStore.ViewModels
                 var dialog = new ContentDialog
                 {
                     Title = ConfirmationDialogStrings.CONFIRMREMOVALTITLE,
-                    Content = string.Format(ConfirmationDialogStrings.CONFIRMREMOVALMESSAGE, game.Name),
+                    Content = string.Format(ConfirmationDialogStrings.CONFIRMREMOVALMESSAGE, game.GameTitle),
                     PrimaryButtonText = ConfirmationDialogStrings.YESBUTTONTEXT,
                     CloseButtonText = ConfirmationDialogStrings.NOBUTTONTEXT,
                     DefaultButton = ContentDialogButton.Primary,

--- a/Source/SteamHub/Data/Queries/Game/AddGameToCart/query.sql
+++ b/Source/SteamHub/Data/Queries/Game/AddGameToCart/query.sql
@@ -1,0 +1,29 @@
+﻿CREATE PROCEDURE AddGameToCart
+    @user_id INT,
+    @game_id INT
+AS
+BEGIN
+    IF EXISTS (SELECT 1 FROM games_users WHERE user_id = @user_id AND game_id = @game_id AND isInCart = 1)
+    BEGIN
+        RAISERROR ('The game is already in the cart.', 16, 1);
+        RETURN;
+    END
+
+    IF EXISTS (SELECT 1 FROM games_users WHERE user_id = @user_id AND game_id = @game_id AND is_purchased = 1)
+    BEGIN
+        RAISERROR ('The game is already purchased.', 16, 1);
+        RETURN;
+    END
+
+    IF EXISTS (SELECT 1 FROM games_users WHERE user_id = @user_id AND game_id = @game_id)
+    BEGIN
+        UPDATE games_users
+        SET isInCart = 1
+        WHERE user_id = @user_id AND game_id = @game_id;
+    END
+    ELSE
+    BEGIN
+        INSERT INTO games_users (user_id, game_id, isInCart)
+        VALUES (@user_id, @game_id, 1);
+    END
+END;

--- a/Source/SteamHub/Data/Queries/Game/Create/query.SQL
+++ b/Source/SteamHub/Data/Queries/Game/Create/query.SQL
@@ -1,0 +1,11 @@
+﻿CREATE PROCEDURE CreateGame
+    @name NVARCHAR(100),
+    @price DECIMAL(18, 2),
+    @publisher_id BIGINT,
+    @description NVARCHAR(1000),
+    @image_url NVARCHAR(1000)
+AS
+BEGIN
+    INSERT INTO Games (name, price, publisher_id, description, image_url)
+    VALUES (@name, @price, @publisher_id, @description, @image_url);
+END;

--- a/Source/SteamHub/Data/Queries/Game/DeleteGameDeveloper/query.sql
+++ b/Source/SteamHub/Data/Queries/Game/DeleteGameDeveloper/query.sql
@@ -1,0 +1,13 @@
+﻿DROP PROCEDURE IF EXISTS DeleteGameDeveloper
+GO
+
+CREATE PROCEDURE DeleteGameDeveloper
+    @game_id INT
+AS
+BEGIN
+    SET NOCOUNT ON;
+    
+    DELETE FROM games
+    WHERE game_id = @game_id;
+END;
+GO

--- a/Source/SteamHub/Data/Queries/Game/DeleteGameFromUserLibraries/query.sql
+++ b/Source/SteamHub/Data/Queries/Game/DeleteGameFromUserLibraries/query.sql
@@ -1,0 +1,13 @@
+DROP PROCEDURE IF EXISTS DeleteGameFromUserLibraries;
+GO
+
+CREATE PROCEDURE DeleteGameFromUserLibraries
+    @game_id INT
+AS
+BEGIN
+    SET NOCOUNT ON;
+    
+    DELETE FROM games_users
+    WHERE game_id = @game_id;
+END;
+GO 

--- a/Source/SteamHub/Data/Queries/Game/DeleteGameTag/query.sql
+++ b/Source/SteamHub/Data/Queries/Game/DeleteGameTag/query.sql
@@ -1,0 +1,14 @@
+DROP PROCEDURE IF EXISTS DeleteGameTag;
+GO
+
+CREATE PROCEDURE DeleteGameTag
+    @game_id INT,
+    @tag_id INT
+AS
+BEGIN
+    SET NOCOUNT ON;
+    
+    DELETE FROM game_tags
+    WHERE game_id = @game_id AND tag_id = @tag_id;
+END;
+GO 

--- a/Source/SteamHub/Data/Queries/Game/DeleteGameTags/query.sql
+++ b/Source/SteamHub/Data/Queries/Game/DeleteGameTags/query.sql
@@ -1,0 +1,13 @@
+DROP PROCEDURE IF EXISTS DeleteGameTags;
+GO
+
+CREATE PROCEDURE DeleteGameTags
+    @game_id INT
+AS
+BEGIN
+    SET NOCOUNT ON;
+    
+    DELETE FROM game_tags
+    WHERE game_id = @game_id;
+END;
+GO 

--- a/Source/SteamHub/Data/Queries/Game/DeleteGameTransactions/query.sql
+++ b/Source/SteamHub/Data/Queries/Game/DeleteGameTransactions/query.sql
@@ -1,0 +1,13 @@
+DROP PROCEDURE IF EXISTS DeleteGameTransactions;
+GO
+
+CREATE PROCEDURE DeleteGameTransactions
+    @game_id INT
+AS
+BEGIN
+    SET NOCOUNT ON;
+    
+    DELETE FROM store_transaction
+    WHERE game_id = @game_id;
+END;
+GO 

--- a/Source/SteamHub/Data/Queries/Game/GetGameOwnerCount/query.sql
+++ b/Source/SteamHub/Data/Queries/Game/GetGameOwnerCount/query.sql
@@ -1,0 +1,14 @@
+DROP PROCEDURE IF EXISTS GetGameOwnerCount;
+GO
+
+CREATE PROCEDURE GetGameOwnerCount
+    @game_id INT
+AS
+BEGIN
+    SET NOCOUNT ON;
+    
+    SELECT COUNT(*) AS OwnerCount
+    FROM games_users
+    WHERE game_id = @game_id;
+END;
+GO 

--- a/Source/SteamHub/Data/Queries/Game/GetRejectionMessage/query.sql
+++ b/Source/SteamHub/Data/Queries/Game/GetRejectionMessage/query.sql
@@ -1,0 +1,14 @@
+﻿DROP PROCEDURE IF EXISTS GetRejectionMessage
+GO
+
+CREATE PROCEDURE GetRejectionMessage
+    @game_id INT
+AS
+BEGIN
+    SET NOCOUNT ON;
+    
+    SELECT reject_message
+    FROM games
+    WHERE game_id = @game_id;
+END;
+GO

--- a/Source/SteamHub/Data/Queries/Game/GetWishlistGames/query.sql
+++ b/Source/SteamHub/Data/Queries/Game/GetWishlistGames/query.sql
@@ -1,0 +1,11 @@
+CREATE PROCEDURE GetWishlistGames
+    @user_id INT
+AS
+BEGIN
+    SELECT g.game_id, g.name, g.price, g.description, g.image_url, 
+           g.minimum_requirements, g.recommended_requirements, g.status,
+            g.discount
+    FROM games g
+    INNER JOIN games_users gu ON g.game_id = gu.game_id
+    WHERE gu.user_id = @user_id AND gu.isInWishlist = 1 AND g.status = 'Approved';
+END; 

--- a/Source/SteamHub/Data/Queries/Game/InsertGame/query.sql
+++ b/Source/SteamHub/Data/Queries/Game/InsertGame/query.sql
@@ -1,0 +1,28 @@
+﻿DROP PROCEDURE IF EXISTS InsertGame;
+GO
+
+CREATE PROCEDURE InsertGame
+    @game_id INT,
+    @name NVARCHAR(255),
+    @price DECIMAL(10,2),
+    @publisher_id INT,
+    @description NVARCHAR(MAX),
+    @image_url NVARCHAR(MAX),
+    @trailer_url NVARCHAR(MAX),
+    @gameplay_url NVARCHAR(MAX),
+    @minimum_requirements NVARCHAR(MAX),
+    @recommended_requirements NVARCHAR(MAX),
+    @status NVARCHAR(MAX),
+    @discount INT
+AS
+BEGIN
+    SET NOCOUNT ON;
+    
+    INSERT INTO games (game_id, name, price, publisher_id, description, image_url, 
+                      trailer_url, gameplay_url, minimum_requirements, 
+                      recommended_requirements, status, discount, reject_message)
+    VALUES (@game_id, @name, @price, @publisher_id, @description, @image_url, 
+            @trailer_url, @gameplay_url, @minimum_requirements, 
+            @recommended_requirements, @status, @discount, NULL);
+END;
+GO

--- a/Source/SteamHub/Data/Queries/Game/InsertGameTags/query.sql
+++ b/Source/SteamHub/Data/Queries/Game/InsertGameTags/query.sql
@@ -1,0 +1,17 @@
+﻿DROP PROCEDURE IF EXISTS InsertGameTags;
+GO
+
+CREATE PROCEDURE InsertGameTags
+    @game_id INT,
+    @tag_id INT
+AS
+BEGIN
+    SET NOCOUNT ON;
+    
+    IF NOT EXISTS (SELECT 1 FROM game_tags WHERE game_id = @game_id AND tag_id = @tag_id)
+    BEGIN
+        INSERT INTO game_tags (game_id, tag_id)
+        VALUES (@game_id, @tag_id);
+    END
+END;
+GO 

--- a/Source/SteamHub/Data/Queries/Game/IsGameIdInUse/query.sql
+++ b/Source/SteamHub/Data/Queries/Game/IsGameIdInUse/query.sql
@@ -1,0 +1,15 @@
+DROP PROCEDURE IF EXISTS IsGameIdInUse;
+GO
+
+CREATE PROCEDURE IsGameIdInUse
+    @game_id INT
+AS
+BEGIN
+    SET NOCOUNT ON;
+    
+    IF EXISTS (SELECT 1 FROM games WHERE game_id = @game_id)
+        SELECT 1 AS Result;
+    ELSE
+        SELECT 0 AS Result;
+END;
+GO 

--- a/Source/SteamHub/Data/Queries/Game/RejectGame/query.sql
+++ b/Source/SteamHub/Data/Queries/Game/RejectGame/query.sql
@@ -1,0 +1,14 @@
+﻿DROP PROCEDURE IF EXISTS RejectGame
+GO
+
+CREATE PROCEDURE RejectGame
+    @game_id INT
+AS
+BEGIN
+    SET NOCOUNT ON;
+    
+    UPDATE games
+    SET status = 'Rejected'
+    WHERE game_id = @game_id;
+END;
+GO

--- a/Source/SteamHub/Data/Queries/Game/RejectGameWithMessage/query.sql
+++ b/Source/SteamHub/Data/Queries/Game/RejectGameWithMessage/query.sql
@@ -1,0 +1,16 @@
+﻿DROP PROCEDURE IF EXISTS RejectGameWithMessage
+GO
+
+CREATE PROCEDURE RejectGameWithMessage
+    @game_id INT,
+    @rejection_message NVARCHAR(MAX)
+AS
+BEGIN
+    SET NOCOUNT ON;
+    
+    UPDATE games
+    SET status = 'Rejected',
+        reject_message = @rejection_message
+    WHERE game_id = @game_id;
+END;
+GO

--- a/Source/SteamHub/Data/Queries/Game/RemoveGameFromCart/query.sql
+++ b/Source/SteamHub/Data/Queries/Game/RemoveGameFromCart/query.sql
@@ -1,0 +1,17 @@
+﻿CREATE PROCEDURE RemoveGameFromCart
+@user_id INT,
+@game_id INT
+AS
+BEGIN
+	IF EXISTS (SELECT * FROM games_users WHERE user_id = @user_id AND game_id = @game_id)
+		BEGIN
+			UPDATE games_users
+			SET isInCart = 0
+			WHERE user_id = @user_id AND game_id = @game_id;
+		END
+	ELSE
+		BEGIN
+			INSERT INTO games_users (user_id, game_id, is_purchased)
+			VALUES (@user_id, @game_id, 0);
+		END
+END;

--- a/Source/SteamHub/Data/Queries/Game/UpdateGame/query.sql
+++ b/Source/SteamHub/Data/Queries/Game/UpdateGame/query.sql
@@ -1,0 +1,36 @@
+﻿DROP PROCEDURE IF EXISTS UpdateGame
+GO
+
+CREATE PROCEDURE UpdateGame
+    @game_id INT,
+    @name NVARCHAR(255),
+    @price DECIMAL(10,2),
+    @publisher_id INT,
+    @description NVARCHAR(MAX),
+    @image_url NVARCHAR(MAX),
+    @trailer_url NVARCHAR(MAX),
+    @gameplay_url NVARCHAR(MAX),
+    @minimum_requirements NVARCHAR(MAX),
+    @recommended_requirements NVARCHAR(MAX),
+    @status NVARCHAR(MAX),
+    @discount INT
+AS
+BEGIN
+    SET NOCOUNT ON;
+    
+    UPDATE games
+    SET name = @name,
+        price = @price,
+        publisher_id = @publisher_id,
+        description = @description,
+        image_url = @image_url,
+        trailer_url = @trailer_url,
+        gameplay_url = @gameplay_url,
+        minimum_requirements = @minimum_requirements,
+        recommended_requirements = @recommended_requirements,
+        status = @status,
+        discount = @discount,
+        reject_message = NULL
+    WHERE game_id = @game_id;
+END;
+GO

--- a/Source/SteamHub/Data/Queries/Game/addGameToPurchased/query.sql
+++ b/Source/SteamHub/Data/Queries/Game/addGameToPurchased/query.sql
@@ -1,0 +1,17 @@
+﻿CREATE PROCEDURE addGameToPurchased
+	@user_id INT,
+	@game_id INT
+	AS
+	BEGIN
+		IF EXISTS (SELECT * FROM games_users WHERE user_id = @user_id AND game_id = @game_id)
+			BEGIN
+				UPDATE games_users
+				SET is_purchased = 1
+				WHERE user_id = @user_id AND game_id = @game_id;
+			END
+		ELSE
+			BEGIN
+				INSERT INTO games_users (user_id, game_id, is_purchased)
+				VALUES (@user_id, @game_id, 1);
+			END
+	END;

--- a/Source/SteamHub/Data/Queries/Game/addGameToWishlist/query.sql
+++ b/Source/SteamHub/Data/Queries/Game/addGameToWishlist/query.sql
@@ -1,0 +1,23 @@
+﻿CREATE PROCEDURE addGameToWishlist 
+    @user_id INT,
+    @game_id INT
+AS
+BEGIN
+    IF EXISTS (SELECT 1 FROM games_users WHERE user_id = @user_id AND game_id = @game_id AND isInWishlist = 1)
+    BEGIN
+        RAISERROR ('The game is already in the wishlist.', 16, 1);
+        RETURN;
+    END
+
+    IF EXISTS (SELECT 1 FROM games_users WHERE user_id = @user_id AND game_id = @game_id)
+    BEGIN
+        UPDATE games_users
+        SET isInWishlist = 1
+        WHERE user_id = @user_id AND game_id = @game_id;
+    END
+    ELSE
+    BEGIN
+        INSERT INTO games_users (user_id, game_id, isInWishlist)
+        VALUES (@user_id, @game_id, 1);
+    END
+END;

--- a/Source/SteamHub/Data/Queries/Game/getById/query.sql
+++ b/Source/SteamHub/Data/Queries/Game/getById/query.sql
@@ -1,0 +1,6 @@
+﻿CREATE PROCEDURE GetGameById
+    @game_id INT
+AS
+BEGIN
+    SELECT * FROM games WHERE game_id = @game_id;
+END;

--- a/Source/SteamHub/Data/Queries/Game/getGameTags/querry.sql
+++ b/Source/SteamHub/Data/Queries/Game/getGameTags/querry.sql
@@ -1,0 +1,10 @@
+﻿CREATE PROCEDURE getGameTags
+    @gid int
+AS
+BEGIN
+    SELECT t.tag_name, t.tag_id
+    FROM Games g
+    INNER JOIN game_tags gt ON gt.game_id = g.game_id
+    INNER JOIN tags t ON t.tag_id = gt.tag_id
+    WHERE g.game_id=@gid; 
+END;

--- a/Source/SteamHub/Data/Queries/Game/isGamePurchased/query.sql
+++ b/Source/SteamHub/Data/Queries/Game/isGamePurchased/query.sql
@@ -1,0 +1,12 @@
+﻿CREATE PROCEDURE isGamePurchased
+@game_id INT,
+@user_id INT
+AS
+BEGIN
+	SET NOCOUNT ON;
+	
+	IF EXISTS (SELECT 1 FROM games_users WHERE game_id = @game_id AND user_id = @user_id AND is_purchased = 1)
+		SELECT 1 AS Result;
+	ELSE
+		SELECT 0 AS Result;
+END;

--- a/Source/SteamHub/Data/Queries/Game/removeGameFromWishlist/query.sql
+++ b/Source/SteamHub/Data/Queries/Game/removeGameFromWishlist/query.sql
@@ -1,0 +1,16 @@
+﻿CREATE PROCEDURE RemoveGameFromWishlist
+	@user_id INT,
+	@game_id INT
+	AS
+	BEGIN
+		IF EXISTS (SELECT * FROM games_users WHERE user_id = @user_id AND game_id = @game_id)
+			BEGIN
+				UPDATE games_users
+				SET isInWishlist = 0
+				WHERE user_id = @user_id AND game_id = @game_id;
+			END
+		ELSE
+			BEGIN
+				RAISERROR('Game is not in wishlist', 16, 1);
+			END
+	END;

--- a/Source/SteamHub/Data/Queries/Game/validateGame/query.sql
+++ b/Source/SteamHub/Data/Queries/Game/validateGame/query.sql
@@ -1,0 +1,10 @@
+﻿CREATE PROCEDURE ValidateGame
+    @game_id INT
+AS
+BEGIN
+    SET NOCOUNT ON;
+    UPDATE games
+    SET status = 'Approved',
+        reject_message = NULL
+    WHERE game_id = @game_id AND status = 'Pending';
+END;

--- a/Source/SteamHub/Data/Queries/GetAll/CartGames/query.sql
+++ b/Source/SteamHub/Data/Queries/GetAll/CartGames/query.sql
@@ -1,0 +1,9 @@
+﻿CREATE PROCEDURE GetAllCartGames
+    @user_id INT
+AS
+BEGIN
+    SELECT g.game_id, g.name, g.price, g.publisher_id, g.description, g.image_url 
+    FROM games g
+    LEFT JOIN games_users gu ON g.game_id = gu.game_id AND gu.user_id = @user_id
+    WHERE gu.is_purchased = 1 AND g.status = 'Available';
+END;

--- a/Source/SteamHub/Data/Queries/GetAll/Games/query.sql
+++ b/Source/SteamHub/Data/Queries/GetAll/Games/query.sql
@@ -1,0 +1,7 @@
+﻿CREATE PROCEDURE GetAllGames  
+AS  
+BEGIN  
+    SELECT game_id, name, price, publisher_id, description, image_url, minimum_requirements, recommended_requirements, status 
+    FROM Games;  
+END;
+go

--- a/Source/SteamHub/Data/Queries/GetAll/GetAllDeveloperGames/query.sql
+++ b/Source/SteamHub/Data/Queries/GetAll/GetAllDeveloperGames/query.sql
@@ -1,0 +1,12 @@
+﻿DROP PROCEDURE IF EXISTS GetDeveloperGames
+GO
+
+CREATE PROCEDURE GetDeveloperGames
+    @publisher_id INT
+AS
+BEGIN    
+    SELECT *
+    FROM games
+    WHERE publisher_id = @publisher_id;
+END;
+GO

--- a/Source/SteamHub/Data/Queries/GetAll/GetAllUnvalidated/query.sql
+++ b/Source/SteamHub/Data/Queries/GetAll/GetAllUnvalidated/query.sql
@@ -1,0 +1,12 @@
+﻿DROP PROCEDURE IF EXISTS GetAllUnvalidated
+GO
+
+CREATE PROCEDURE GetAllUnvalidated
+    @publisher_id INT
+AS
+BEGIN    
+    SELECT *
+    FROM games
+    WHERE status = 'Pending' AND publisher_id <> @publisher_id;
+END;
+GO

--- a/Source/SteamHub/Data/Queries/GetAll/Tags/query.sql
+++ b/Source/SteamHub/Data/Queries/GetAll/Tags/query.sql
@@ -1,0 +1,4 @@
+﻿CREATE PROCEDURE getAllTags as
+begin
+	Select * from tags
+end

--- a/Source/SteamHub/Data/Queries/Items/AddGameWithItems/query.sql
+++ b/Source/SteamHub/Data/Queries/Items/AddGameWithItems/query.sql
@@ -1,0 +1,45 @@
+﻿drop procedure if exists AddGameWithItems
+go
+
+CREATE PROCEDURE AddGameWithItems
+        @name NVARCHAR(255),
+        @price DECIMAL(10,2),
+        @publisher_id INT,
+        @description NVARCHAR(MAX),
+        @image_url NVARCHAR(MAX),
+        @trailer_url NVARCHAR(MAX),
+        @gameplay_url NVARCHAR(MAX),
+        @minimum_requirements NVARCHAR(MAX),
+        @recommended_requirements NVARCHAR(MAX),
+        @status NVARCHAR(MAX),
+        @discount INT,
+        @ItemName NVARCHAR(100),
+        @ItemPrice FLOAT,
+        @ItemDescription NVARCHAR(MAX)
+    AS
+    BEGIN
+        DECLARE @GameId INT;
+        
+        -- Check if game exists
+        SELECT @GameId = game_id FROM Games WHERE Name = @name;
+        
+        -- If game doesn''t exist, create it
+        IF @GameId IS NULL
+        BEGIN
+            
+        INSERT INTO games (game_id, name, price, publisher_id, description, image_url, 
+                          trailer_url, gameplay_url, minimum_requirements, 
+                          recommended_requirements, status, discount, reject_message)
+        VALUES (@game_id, @name, @price, @publisher_id, @description, @image_url, 
+                @trailer_url, @gameplay_url, @minimum_requirements, 
+                @recommended_requirements, 'Available', @discount, NULL);
+            
+            SET @GameId = SCOPE_IDENTITY();
+        END
+        
+        -- Insert the item
+        INSERT INTO Items (ItemName, CorrespondingGameId, Price, Description, IsListed)
+        VALUES (@ItemName, @GameId, @ItemPrice, @ItemDescription, 0);
+        
+        SELECT @GameId AS GameId;
+    END

--- a/Source/SteamHub/Data/Queries/Items/AddToUserInventory/query.sql
+++ b/Source/SteamHub/Data/Queries/Items/AddToUserInventory/query.sql
@@ -1,0 +1,15 @@
+﻿drop procedure if exists AddToUserInventory
+go
+
+ CREATE PROCEDURE AddToUserInventory
+        @UserId INT,
+        @ItemId INT,
+        @GameId INT
+    AS
+    BEGIN
+        IF NOT EXISTS (SELECT 1 FROM UserInventory WHERE UserId = @UserId AND ItemId = @ItemId AND GameId = @GameId)
+        BEGIN
+            INSERT INTO UserInventory (UserId, ItemId, GameId)
+            VALUES (@UserId, @ItemId, @GameId);
+        END
+    END

--- a/Source/SteamHub/Data/Queries/Items/GetAllItemsFromInventory/query.sql
+++ b/Source/SteamHub/Data/Queries/Items/GetAllItemsFromInventory/query.sql
@@ -1,0 +1,20 @@
+﻿CREATE PROCEDURE GetAllItemsFromInventory
+    @UserId INT
+AS
+BEGIN
+    SELECT 
+        i.ItemId,
+        i.ItemName,
+        i.Price,
+        i.Description,
+        i.IsListed,
+        g.game_id,
+        g.name,
+        g.description AS GameDescription,
+        g.price AS GamePrice,
+        g.status AS GameStatus
+    FROM Items i
+    JOIN UserInventory ui ON i.ItemId = ui.ItemId
+    JOIN Games g ON ui.game_id = g.game_id
+    WHERE ui.user_id = @UserId;
+END

--- a/Source/SteamHub/Data/Queries/Items/GetItemsFromInventory/query.sql
+++ b/Source/SteamHub/Data/Queries/Items/GetItemsFromInventory/query.sql
@@ -1,0 +1,15 @@
+﻿CREATE PROCEDURE GetItemsFromInventory
+    @GameId INT,
+    @UserId INT
+AS
+BEGIN
+    SELECT 
+        i.ItemId,
+        i.ItemName,
+        i.Price,
+        i.Description,
+        i.IsListed
+    FROM Items i
+    JOIN UserInventory ui ON i.ItemId = ui.ItemId
+    WHERE ui.game_id = @GameId AND ui.user_id = @UserId;
+END

--- a/Source/SteamHub/Data/Queries/Items/GetListedItemsByGame/query.sql
+++ b/Source/SteamHub/Data/Queries/Items/GetListedItemsByGame/query.sql
@@ -1,0 +1,20 @@
+﻿CREATE PROCEDURE GetListedItemsByGame
+    @GameId INT
+AS
+BEGIN
+    SELECT 
+        i.ItemId, 
+        i.ItemName, 
+        i.Price, 
+        i.Description, 
+        i.IsListed,
+        g.game_id, 
+        g.name AS GameTitle, 
+        g.description AS GameDescription,
+        g.price AS GamePrice, 
+        g.status AS GameStatus
+    FROM Items i
+    JOIN UserInventory ui ON i.ItemId = ui.ItemId
+    JOIN Games g ON ui.game_id = g.GameId
+    WHERE g.game_id = @GameId AND i.IsListed = 1;
+END

--- a/Source/SteamHub/Data/Queries/Items/GetUserInventory/query.sql
+++ b/Source/SteamHub/Data/Queries/Items/GetUserInventory/query.sql
@@ -1,0 +1,21 @@
+﻿CREATE PROCEDURE GetUserInventory
+    @UserId INT
+AS
+BEGIN
+    SELECT 
+        i.ItemId,
+        i.ItemName,
+        i.Price,
+        i.Description,
+        i.IsListed,
+        g.game_id,
+        g.name,
+        g.description AS GameDescription,
+        g.price AS GamePrice,
+        g.status AS GameStatus
+    FROM Items i
+    JOIN Games g ON i.CorrespondingGameId = g.game_id
+    JOIN UserInventory ui ON i.ItemId = ui.ItemId AND g.game_id = ui.game_id
+    WHERE ui.user_id = @UserId
+    ORDER BY g.name, i.price;
+END

--- a/Source/SteamHub/Data/Queries/Items/MakeItemListable/query.sql
+++ b/Source/SteamHub/Data/Queries/Items/MakeItemListable/query.sql
@@ -1,0 +1,9 @@
+﻿CREATE PROCEDURE MakeItemListable
+    @ItemId INT,
+    @Price FLOAT
+AS
+BEGIN
+    UPDATE Items
+    SET IsListed = 1, Price = @Price
+    WHERE ItemId = @ItemId;
+END

--- a/Source/SteamHub/Data/Queries/Items/MakeItemNotListable/query.sql
+++ b/Source/SteamHub/Data/Queries/Items/MakeItemNotListable/query.sql
@@ -1,0 +1,8 @@
+﻿CREATE PROCEDURE MakeItemNotListable
+    @ItemId INT
+AS
+BEGIN
+    UPDATE Items
+    SET IsListed = 0
+    WHERE ItemId = @ItemId;
+END

--- a/Source/SteamHub/Data/Queries/Items/RemoveFromUserInventory/query.sql
+++ b/Source/SteamHub/Data/Queries/Items/RemoveFromUserInventory/query.sql
@@ -1,0 +1,12 @@
+﻿ drop procedure if exists RemoveFromUserInventory
+ go
+ 
+ CREATE PROCEDURE RemoveFromUserInventory
+        @UserId INT,
+        @ItemId INT,
+        @GameId INT
+    AS
+    BEGIN
+        DELETE FROM UserInventory 
+        WHERE UserId = @UserId AND ItemId = @ItemId AND GameId = @GameId;
+    END

--- a/Source/SteamHub/Data/Queries/User/Create/query.sql
+++ b/Source/SteamHub/Data/Queries/User/Create/query.sql
@@ -1,0 +1,10 @@
+﻿CREATE PROCEDURE CreateUser
+    @Username NVARCHAR(30),
+    @Balance DECIMAL(10, 2),
+    @PointBalance DECIMAL(10, 2),
+    @isDeveloper BIT
+AS
+BEGIN
+    INSERT INTO Users (Username, Balance, PointBalance, isDeveloper)
+    VALUES (@Username, @Balance, @PointBalance, @isDeveloper)
+END;

--- a/Source/SteamHub/Data/Queries/User/Create/query.sql
+++ b/Source/SteamHub/Data/Queries/User/Create/query.sql
@@ -2,9 +2,10 @@
     @Username NVARCHAR(30),
     @Balance DECIMAL(10, 2),
     @PointBalance DECIMAL(10, 2),
-    @isDeveloper BIT
+    @isDeveloper BIT,
+    @useremail NVARCHAR(255)
 AS
 BEGIN
-    INSERT INTO Users (Username, Balance, PointBalance, isDeveloper)
-    VALUES (@Username, @Balance, @PointBalance, @isDeveloper)
+    INSERT INTO Users (Username, Balance, PointBalance, isDeveloper, email)
+    VALUES (@Username, @Balance, @PointBalance, @isDeveloper, @useremail)
 END;

--- a/Source/SteamHub/Data/Queries/User/GetAllUsers/query.sql
+++ b/Source/SteamHub/Data/Queries/User/GetAllUsers/query.sql
@@ -6,6 +6,7 @@ BEGIN
         username AS UserName,
         balance AS WalletBalance,
         point_balance AS PointBalance,
-        is_developer AS IsDeveloper
+        is_developer AS IsDeveloper,
+        email as useremail
     FROM users;
 END

--- a/Source/SteamHub/Data/Queries/User/GetAllUsers/query.sql
+++ b/Source/SteamHub/Data/Queries/User/GetAllUsers/query.sql
@@ -1,0 +1,11 @@
+﻿CREATE PROCEDURE GetAllUsers
+AS
+BEGIN
+    SELECT 
+        user_id AS UserId,
+        username AS UserName,
+        balance AS WalletBalance,
+        point_balance AS PointBalance,
+        is_developer AS IsDeveloper
+    FROM users;
+END

--- a/Source/SteamHub/Data/Queries/User/GetById/query.sql
+++ b/Source/SteamHub/Data/Queries/User/GetById/query.sql
@@ -1,0 +1,6 @@
+﻿CREATE PROCEDURE GetUserById
+    @UserId INT
+AS
+BEGIN
+    SELECT * FROM users WHERE user_id = @UserId;
+END;

--- a/Source/SteamHub/Data/Queries/User/UpdateUser/query.sql
+++ b/Source/SteamHub/Data/Queries/User/UpdateUser/query.sql
@@ -1,0 +1,16 @@
+﻿CREATE PROCEDURE UpdateUser
+    @UserId INT,
+    @UserName NVARCHAR(255),
+    @WalletBalance DECIMAL(10,2),
+    @PointBalance DECIMAL(10,2),
+    @IsDeveloper BIT
+AS
+BEGIN
+    UPDATE users
+    SET 
+        username = @UserName,
+        balance = @WalletBalance,
+        point_balance = @PointBalance,
+        is_developer = @IsDeveloper
+    WHERE user_id = @UserId;
+END

--- a/Source/SteamHub/Data/Queries/User/UpdateUser/query.sql
+++ b/Source/SteamHub/Data/Queries/User/UpdateUser/query.sql
@@ -3,7 +3,8 @@
     @UserName NVARCHAR(255),
     @WalletBalance DECIMAL(10,2),
     @PointBalance DECIMAL(10,2),
-    @IsDeveloper BIT
+    @IsDeveloper BIT,
+    @useremail NVARCHAR(255)
 AS
 BEGIN
     UPDATE users
@@ -11,6 +12,7 @@ BEGIN
         username = @UserName,
         balance = @WalletBalance,
         point_balance = @PointBalance,
-        is_developer = @IsDeveloper
+        is_developer = @IsDeveloper,
+        email=@useremail
     WHERE user_id = @UserId;
 END

--- a/Source/SteamHub/Data/Queries/Wishlist/AddGameToWishlist.sql
+++ b/Source/SteamHub/Data/Queries/Wishlist/AddGameToWishlist.sql
@@ -1,0 +1,33 @@
+DROP PROCEDURE IF EXISTS AddGameToWishlist;
+GO
+
+CREATE PROCEDURE AddGameToWishlist
+    @user_id INT,
+    @game_id INT
+AS
+BEGIN
+    IF EXISTS (SELECT 1 FROM games_users WHERE user_id = @user_id AND game_id = @game_id AND isInWishlist = 1)
+    BEGIN
+        RAISERROR ('Game is already in wishlist', 16, 1);
+        RETURN;
+    END
+
+    IF EXISTS (SELECT 1 FROM games_users WHERE user_id = @user_id AND game_id = @game_id AND is_purchased = 1)
+    BEGIN
+        RAISERROR ('Game is already purchased', 16, 1);
+        RETURN;
+    END
+
+    IF NOT EXISTS (SELECT 1 FROM games_users WHERE user_id = @user_id AND game_id = @game_id)
+    BEGIN
+        INSERT INTO games_users (user_id, game_id, isInWishlist, is_purchased, isInCart)
+        VALUES (@user_id, @game_id, 1, 0, 0);
+    END
+    ELSE
+    BEGIN
+        UPDATE games_users
+        SET isInWishlist = 1
+        WHERE user_id = @user_id AND game_id = @game_id;
+    END
+END;
+GO 

--- a/Source/SteamHub/Data/Queries/Wishlist/GetWishlistGames.sql
+++ b/Source/SteamHub/Data/Queries/Wishlist/GetWishlistGames.sql
@@ -1,0 +1,14 @@
+DROP PROCEDURE IF EXISTS GetWishlistGames;
+GO
+
+CREATE PROCEDURE GetWishlistGames
+    @user_id INT
+AS
+BEGIN
+    SELECT g.game_id, g.name, g.price, g.publisher_id, g.description, g.image_url, g.discount, g.status,
+           gu.is_purchased, gu.isInCart, gu.isInWishlist
+    FROM games g
+    LEFT JOIN games_users gu ON g.game_id = gu.game_id AND gu.user_id = @user_id
+    WHERE gu.isInWishlist = 1 AND g.status = 'Approved';
+END;
+GO 

--- a/Source/SteamHub/Data/Queries/Wishlist/RemoveGameFromWishlist.sql
+++ b/Source/SteamHub/Data/Queries/Wishlist/RemoveGameFromWishlist.sql
@@ -1,0 +1,19 @@
+DROP PROCEDURE IF EXISTS RemoveGameFromWishlist;
+GO
+
+CREATE PROCEDURE RemoveGameFromWishlist
+    @user_id INT,
+    @game_id INT
+AS
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM games_users WHERE user_id = @user_id AND game_id = @game_id AND isInWishlist = 1)
+    BEGIN
+        RAISERROR ('Game is not in wishlist', 16, 1);
+        RETURN;
+    END
+
+    UPDATE games_users
+    SET isInWishlist = 0
+    WHERE user_id = @user_id AND game_id = @game_id;
+END;
+GO 

--- a/Source/SteamHub/Data/Schema/Schema.sql
+++ b/Source/SteamHub/Data/Schema/Schema.sql
@@ -1,0 +1,95 @@
+﻿
+CREATE TABLE users (
+    user_id INT PRIMARY KEY,
+	username NVARCHAR(255),
+    balance DECIMAL(10,2),
+    point_balance DECIMAL(10,2),
+    is_developer BIT
+);
+
+CREATE TABLE games (
+    game_id INT PRIMARY KEY,
+    name NVARCHAR(255),
+    price DECIMAL(10,2),
+    publisher_id INT FOREIGN KEY REFERENCES users(user_id),
+    description NVARCHAR(MAX),
+    image_url NVARCHAR(MAX),
+	minimum_requirements NVARCHAR(MAX),
+	recommended_requirements NVARCHAR(MAX),
+	status NVARCHAR(MAX)
+);
+
+CREATE TABLE tags (
+    tag_id INT PRIMARY KEY,
+    tag_name NVARCHAR(255)
+);
+
+CREATE TABLE game_tags (
+    tag_id INT FOREIGN KEY REFERENCES tags(tag_id),
+    game_id INT FOREIGN KEY REFERENCES games(game_id),
+    PRIMARY KEY (tag_id, game_id)
+);
+
+CREATE TABLE games_users (
+    user_id INT FOREIGN KEY REFERENCES users(user_id),
+    game_id INT FOREIGN KEY REFERENCES games(game_id),
+    isInWishlist BIT,
+    is_purchased BIT,
+     isInCart BIT,
+    PRIMARY KEY (user_id, game_id)
+);
+
+CREATE TABLE store_transaction (
+    game_id INT FOREIGN KEY REFERENCES games(game_id),
+    user_id INT FOREIGN KEY REFERENCES users(user_id),
+    date DATETIME,
+    amount DECIMAL(10, 2),
+    withMoney BIT
+);
+
+CREATE TABLE point_items (
+    point_item_id INT PRIMARY KEY,
+    name NVARCHAR(255),
+    description NVARCHAR(MAX),
+    price DECIMAL(10, 2),
+    image_url NVARCHAR(MAX)
+);
+
+CREATE TABLE users_items (
+    user_id INT FOREIGN KEY REFERENCES users(user_id),
+    item_id INT FOREIGN KEY REFERENCES point_items(point_item_id)
+);
+
+CREATE TABLE Items (
+    ItemId INT PRIMARY KEY IDENTITY(1,1),
+    ItemName NVARCHAR(100) NOT NULL,
+    CorrespondingGameId INT FOREIGN KEY REFERENCES Games(game_id),
+    Price FLOAT NOT NULL,
+    Description NVARCHAR(MAX),
+    IsListed BIT NOT NULL DEFAULT 0
+);
+CREATE TABLE UserInventory (
+        UserId INT FOREIGN KEY REFERENCES Users(user_id),
+        ItemId INT FOREIGN KEY REFERENCES Items(ItemId),
+        GameId INT FOREIGN KEY REFERENCES Games(game_id),
+        AcquiredDate DATETIME NOT NULL DEFAULT GETUTCDATE(),
+        PRIMARY KEY (UserId, ItemId, GameId)
+    );
+CREATE TABLE ItemTrades (
+        TradeId INT PRIMARY KEY IDENTITY(1,1),
+        SourceUserId INT FOREIGN KEY REFERENCES Users(user_id),
+        DestinationUserId INT FOREIGN KEY REFERENCES Users(user_id),
+        GameOfTradeId INT FOREIGN KEY REFERENCES Games(game_id),
+        TradeDate DATETIME NOT NULL DEFAULT GETUTCDATE(),
+        TradeDescription NVARCHAR(MAX),
+        TradeStatus NVARCHAR(20) NOT NULL DEFAULT 'Pending',
+        AcceptedBySourceUser BIT NOT NULL DEFAULT 0,
+        AcceptedByDestinationUser BIT NOT NULL DEFAULT 0
+    );
+
+CREATE TABLE ItemTradeDetails (
+        TradeId INT FOREIGN KEY REFERENCES ItemTrades(TradeId),
+        ItemId INT FOREIGN KEY REFERENCES Items(ItemId),
+        IsSourceUserItem BIT NOT NULL, -- True if item is from source user, False if from destination user
+        PRIMARY KEY (TradeId, ItemId)
+    );

--- a/Source/SteamHub/Data/Schema/Schema.sql
+++ b/Source/SteamHub/Data/Schema/Schema.sql
@@ -9,15 +9,19 @@ CREATE TABLE users (
 );
 
 CREATE TABLE games (
-    game_id INT PRIMARY KEY,
-    name NVARCHAR(255),
-    price DECIMAL(10,2),
-    publisher_id INT FOREIGN KEY REFERENCES users(user_id),
-    description NVARCHAR(MAX),
-    image_url NVARCHAR(MAX),
-	minimum_requirements NVARCHAR(MAX),
-	recommended_requirements NVARCHAR(MAX),
-	status NVARCHAR(MAX)
+game_id INT PRIMARY KEY,
+name NVARCHAR(255),
+price DECIMAL(10,2),
+publisher_id INT FOREIGN KEY REFERENCES users(user_id),
+description NVARCHAR(MAX),
+image_url NVARCHAR(MAX),
+trailer_url NVARCHAR(MAX),
+gameplay_url NVARCHAR(MAX),
+minimum_requirements NVARCHAR(MAX),
+recommended_requirements NVARCHAR(MAX),
+status NVARCHAR(MAX),
+discount INT,
+reject_message NVARCHAR(MAX) NULL
 );
 
 CREATE TABLE tags (

--- a/Source/SteamHub/Data/Schema/Schema.sql
+++ b/Source/SteamHub/Data/Schema/Schema.sql
@@ -4,7 +4,8 @@ CREATE TABLE users (
 	username NVARCHAR(255),
     balance DECIMAL(10,2),
     point_balance DECIMAL(10,2),
-    is_developer BIT
+    is_developer BIT,
+    email NVARCHAR(255)
 );
 
 CREATE TABLE games (
@@ -93,3 +94,23 @@ CREATE TABLE ItemTradeDetails (
         IsSourceUserItem BIT NOT NULL, -- True if item is from source user, False if from destination user
         PRIMARY KEY (TradeId, ItemId)
     );
+go
+
+CREATE TABLE PointShopItems (
+    ItemId INT PRIMARY KEY,
+    Name NVARCHAR(255) NOT NULL,
+    Description NVARCHAR(MAX),
+    ImagePath NVARCHAR(MAX),
+    PointPrice DECIMAL(10, 2) NOT NULL,
+    ItemType NVARCHAR(50) NOT NULL -- E.g., "ProfileBackground", "Avatar", "Emoticon", etc.
+);
+
+CREATE TABLE UserInventoryItems (
+    UserId INT,
+    ItemId INT,
+    PurchaseDate DATETIME DEFAULT GETDATE(),
+    IsActive BIT DEFAULT 0,
+    PRIMARY KEY (UserId, ItemId),
+    FOREIGN KEY (ItemId) REFERENCES PointShopItems(ItemId)
+);
+GO

--- a/Source/SteamHub/Data/Schema/Schema.sql
+++ b/Source/SteamHub/Data/Schema/Schema.sql
@@ -48,19 +48,6 @@ CREATE TABLE store_transaction (
     withMoney BIT
 );
 
-CREATE TABLE point_items (
-    point_item_id INT PRIMARY KEY,
-    name NVARCHAR(255),
-    description NVARCHAR(MAX),
-    price DECIMAL(10, 2),
-    image_url NVARCHAR(MAX)
-);
-
-CREATE TABLE users_items (
-    user_id INT FOREIGN KEY REFERENCES users(user_id),
-    item_id INT FOREIGN KEY REFERENCES point_items(point_item_id)
-);
-
 CREATE TABLE Items (
     ItemId INT PRIMARY KEY IDENTITY(1,1),
     ItemName NVARCHAR(100) NOT NULL,

--- a/Source/SteamHub/Models/Game.cs
+++ b/Source/SteamHub/Models/Game.cs
@@ -1,0 +1,53 @@
+// <copyright file="Game.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace SteamHub.Models
+{
+    using System;
+    using System.Runtime.Intrinsics.X86;
+    using Windows.Devices.Pwm;
+
+    public class Game
+    {
+        public const decimal NOTCOMPUTED = -111111;
+
+        public Game()
+        {
+        }
+
+        public int GameId { get; set; }
+
+        public string GameTitle { get; set; }
+
+        public string GameDescription { get; set; }
+
+        public string ImagePath { get; set; }
+
+        public decimal Price { get; set; }
+
+        public string MinimumRequirements { get; set; }
+
+        public string RecommendedRequirements { get; set; }
+
+        public string Status { get; set; }
+
+        public string[] Tags { get; set; }
+
+        public decimal Rating { get; set; }
+
+        public int NumberOfRecentPurchases { get; set; }
+
+        public decimal TrendingScore { get; set; }
+
+        public string TrailerPath { get; set; }
+
+        public string GameplayPath { get; set; }
+
+        public decimal Discount { get; set; }
+
+        public decimal TagScore { get; set; }
+
+        public int PublisherIdentifier { get; set; }
+    }
+}

--- a/Source/SteamHub/Models/Item.cs
+++ b/Source/SteamHub/Models/Item.cs
@@ -8,43 +8,21 @@
     /// </summary>
     public class Item
     {
-        private const string ImageBasePath = "ms-appx:///Assets/img/games/";
-        private const string GameTitleCounterStrike = "counter-strike 2";
-        private const string GameTitleDota = "dota 2";
-        private const string GameTitleTeamFortress = "team fortress 2";
+        public const string GameTitleCounterStrike = "counter-strike 2";
+        public const string GameTitleDota = "dota 2";
+        public const string GameTitleTeamFortress = "team fortress 2";
 
-        private const string GameFolderCounterStrike = "cs2";
-        private const string GameFolderDota = "dota2";
-        private const string GameFolderTeamFortress = "tf2";
+        public const string GameFolderCounterStrike = "cs2";
+        public const string GameFolderDota = "dota2";
+        public const string GameFolderTeamFortress = "tf2";
 
-        private int itemId;
-        private string itemName = default!;
-        private Game associatedGame = default!;
-        private float price;
-        private string description = default!;
-        private bool isItemListed;
-        private string imagePath = default!;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Item"/> class with provided values.
-        /// </summary>
-        /// <param name="itemName">The name of the item.</param>
-        /// <param name="game">The game to which the item belongs.</param>
-        /// <param name="price">The price of the item.</param>
-        /// <param name="description">The description of the item.</param>
-        public Item(string itemName, Game game, float price, string description)
-        {
-            itemName = itemName ?? throw new ArgumentNullException(nameof(itemName));
-            game = game ?? throw new ArgumentNullException(nameof(game));
-            description = description ?? throw new ArgumentNullException(nameof(description));
-            this.itemName = itemName;
-            this.associatedGame = game;
-            this.price = price;
-            this.isItemListed = false;
-            this.description = description;
-
-            Debug.WriteLine($"Created item {itemName}, waiting for ItemId to set image path");
-        }
+        public int ItemId { get; set; }
+        public string ItemName { get; set; } = default!;
+        public Game Game { get; set; } = default!;
+        public float Price { get; set; }
+        public string Description { get; set; } = default!;
+        public bool isListed { get; set; }
+        public string ImagePath { get; set; } = default!;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Item"/> class for EF Core.
@@ -52,140 +30,5 @@
         private Item()
         {
         }
-
-        /// <summary>
-        /// Gets or sets the unique identifier of the item.
-        /// </summary>
-        public int ItemId
-        {
-            get => this.itemId;
-            set => this.itemId = value;
-        }
-
-        /// <summary>
-        /// Gets or sets the name of the item.
-        /// </summary>
-        public string ItemName
-        {
-            get => this.itemName;
-            set => this.itemName = value;
-        }
-
-        /// <summary>
-        /// Gets or sets the game associated with the item.
-        /// </summary>
-        public Game Game
-        {
-            get => this.associatedGame;
-            set => this.associatedGame = value;
-        }
-
-        /// <summary>
-        /// Gets or sets the price of the item.
-        /// </summary>
-        public float Price
-        {
-            get => this.price;
-            set => this.price = value;
-        }
-
-        /// <summary>
-        /// Gets or sets the description of the item.
-        /// </summary>
-        public string Description
-        {
-            get => this.description;
-            set => this.description = value;
-        }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether the item is listed.
-        /// </summary>
-        public bool IsListed
-        {
-            get => this.isItemListed;
-            set => this.isItemListed = value;
-        }
-
-        /// <summary>
-        /// Gets or sets the image path for the item.
-        /// </summary>
-        public string ImagePath
-        {
-            get => this.imagePath;
-            set => this.imagePath = value;
-        }
-
-        /// <summary>
-        /// Gets the name of the item.
-        /// </summary>
-        /// <returns>The item name.</returns>
-        public string GetItemName()
-        {
-            return this.itemName;
-        }
-
-        /// <summary>
-        /// Gets the game associated with the item.
-        /// </summary>
-        /// <returns>The corresponding game.</returns>
-        public Game GetCorrespondingGame()
-        {
-            return this.associatedGame;
-        }
-
-        /// <summary>
-        /// Sets the item description.
-        /// </summary>
-        /// <param name="description">The new description.</param>
-        public void SetItemDescription(string description)
-        {
-            this.description = description;
-        }
-
-        /// <summary>
-        /// Sets the unique identifier of the item and generates its image path.
-        /// </summary>
-        /// <param name="id">The identifier to assign.</param>
-        public void SetItemId(int id)
-        {
-            this.itemId = id;
-
-            this.imagePath = this.GetDefaultImagePath(this.itemName);
-            Debug.WriteLine($"Set ItemId {id} and image path: {this.imagePath}");
-        }
-
-        /// <summary>
-        /// Sets whether the item is listed.
-        /// </summary>
-        /// <param name="isListed">True if listed; otherwise, false.</param>
-        public void SetIsListed(bool isListed)
-        {
-            this.isItemListed = isListed;
-        }
-
-        /// <summary>
-        /// Sets the image path for the item.
-        /// </summary>
-        /// <param name="imagePath">The image path to assign.</param>
-        public void SetImagePath(string imagePath)
-        {
-            Debug.WriteLine($"Setting image path for {this.itemName}: {imagePath}");
-            this.imagePath = imagePath;
-        }
-
-        /// <summary>
-        /// Generates a default image path for the item based on the game title and item ID.
-        /// </summary>
-        /// <param name="itemName">The name of the item.</param>
-        /// <returns>The generated image path.</returns>
-        private string GetDefaultImagePath(string itemName)
-        {
-            string gameFolder = GameFolderResolver.GetFolderName(this.associatedGame.GameTitle);
-            var path = $"{ImageBasePath}{gameFolder}/{this.itemId}.png";
-            Debug.WriteLine($"Generated image path for item {this.itemId} ({itemName}) from {this.associatedGame.GameTitle}: {path}");
-            return path;
-        }
-
     }
 }

--- a/Source/SteamHub/Models/Item.cs
+++ b/Source/SteamHub/Models/Item.cs
@@ -1,0 +1,191 @@
+﻿namespace SteamHub.Models
+{
+    using System;
+    using System.Diagnostics;
+
+    /// <summary>
+    /// Represents an item that can be listed and traded in the game system.
+    /// </summary>
+    public class Item
+    {
+        private const string ImageBasePath = "ms-appx:///Assets/img/games/";
+        private const string GameTitleCounterStrike = "counter-strike 2";
+        private const string GameTitleDota = "dota 2";
+        private const string GameTitleTeamFortress = "team fortress 2";
+
+        private const string GameFolderCounterStrike = "cs2";
+        private const string GameFolderDota = "dota2";
+        private const string GameFolderTeamFortress = "tf2";
+
+        private int itemId;
+        private string itemName = default!;
+        private Game associatedGame = default!;
+        private float price;
+        private string description = default!;
+        private bool isItemListed;
+        private string imagePath = default!;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Item"/> class with provided values.
+        /// </summary>
+        /// <param name="itemName">The name of the item.</param>
+        /// <param name="game">The game to which the item belongs.</param>
+        /// <param name="price">The price of the item.</param>
+        /// <param name="description">The description of the item.</param>
+        public Item(string itemName, Game game, float price, string description)
+        {
+            itemName = itemName ?? throw new ArgumentNullException(nameof(itemName));
+            game = game ?? throw new ArgumentNullException(nameof(game));
+            description = description ?? throw new ArgumentNullException(nameof(description));
+            this.itemName = itemName;
+            this.associatedGame = game;
+            this.price = price;
+            this.isItemListed = false;
+            this.description = description;
+
+            Debug.WriteLine($"Created item {itemName}, waiting for ItemId to set image path");
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Item"/> class for EF Core.
+        /// </summary>
+        private Item()
+        {
+        }
+
+        /// <summary>
+        /// Gets or sets the unique identifier of the item.
+        /// </summary>
+        public int ItemId
+        {
+            get => this.itemId;
+            set => this.itemId = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the name of the item.
+        /// </summary>
+        public string ItemName
+        {
+            get => this.itemName;
+            set => this.itemName = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the game associated with the item.
+        /// </summary>
+        public Game Game
+        {
+            get => this.associatedGame;
+            set => this.associatedGame = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the price of the item.
+        /// </summary>
+        public float Price
+        {
+            get => this.price;
+            set => this.price = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the description of the item.
+        /// </summary>
+        public string Description
+        {
+            get => this.description;
+            set => this.description = value;
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the item is listed.
+        /// </summary>
+        public bool IsListed
+        {
+            get => this.isItemListed;
+            set => this.isItemListed = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the image path for the item.
+        /// </summary>
+        public string ImagePath
+        {
+            get => this.imagePath;
+            set => this.imagePath = value;
+        }
+
+        /// <summary>
+        /// Gets the name of the item.
+        /// </summary>
+        /// <returns>The item name.</returns>
+        public string GetItemName()
+        {
+            return this.itemName;
+        }
+
+        /// <summary>
+        /// Gets the game associated with the item.
+        /// </summary>
+        /// <returns>The corresponding game.</returns>
+        public Game GetCorrespondingGame()
+        {
+            return this.associatedGame;
+        }
+
+        /// <summary>
+        /// Sets the item description.
+        /// </summary>
+        /// <param name="description">The new description.</param>
+        public void SetItemDescription(string description)
+        {
+            this.description = description;
+        }
+
+        /// <summary>
+        /// Sets the unique identifier of the item and generates its image path.
+        /// </summary>
+        /// <param name="id">The identifier to assign.</param>
+        public void SetItemId(int id)
+        {
+            this.itemId = id;
+
+            this.imagePath = this.GetDefaultImagePath(this.itemName);
+            Debug.WriteLine($"Set ItemId {id} and image path: {this.imagePath}");
+        }
+
+        /// <summary>
+        /// Sets whether the item is listed.
+        /// </summary>
+        /// <param name="isListed">True if listed; otherwise, false.</param>
+        public void SetIsListed(bool isListed)
+        {
+            this.isItemListed = isListed;
+        }
+
+        /// <summary>
+        /// Sets the image path for the item.
+        /// </summary>
+        /// <param name="imagePath">The image path to assign.</param>
+        public void SetImagePath(string imagePath)
+        {
+            Debug.WriteLine($"Setting image path for {this.itemName}: {imagePath}");
+            this.imagePath = imagePath;
+        }
+
+        /// <summary>
+        /// Generates a default image path for the item based on the game title and item ID.
+        /// </summary>
+        /// <param name="itemName">The name of the item.</param>
+        /// <returns>The generated image path.</returns>
+        private string GetDefaultImagePath(string itemName)
+        {
+            string gameFolder = GameFolderResolver.GetFolderName(this.associatedGame.GameTitle);
+            var path = $"{ImageBasePath}{gameFolder}/{this.itemId}.png";
+            Debug.WriteLine($"Generated image path for item {this.itemId} ({itemName}) from {this.associatedGame.GameTitle}: {path}");
+            return path;
+        }
+
+    }
+}

--- a/Source/SteamHub/Models/ItemTrade.cs
+++ b/Source/SteamHub/Models/ItemTrade.cs
@@ -1,0 +1,187 @@
+﻿namespace SteamHub.Models
+{
+    using System;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Represents a trade between two users involving items from a specific game.
+    /// </summary>
+    public class ItemTrade
+    {
+        private const string StatusPending = "Pending";
+        private const string StatusCompleted = "Completed";
+        private const string StatusDeclined = "Declined";
+
+        private int tradeId;
+        private User sourceUser;
+        private User destinationUser;
+        private Game gameOfTrade;
+        private DateTime tradeDate;
+        private string tradeDescription;
+        private string tradeStatus;
+        private bool acceptedBySourceUser;
+        private bool acceptedByDestinationUser;
+        private List<Item> sourceUserItems;
+        private List<Item> destinationUserItems;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ItemTrade"/> class.
+        /// </summary>
+        /// <param name="sourceUser">The user initiating the trade.</param>
+        /// <param name="destinationUser">The user receiving the trade.</param>
+        /// <param name="gameOfTrade">The game the items belong to.</param>
+        /// <param name="description">The description of the trade.</param>
+        public ItemTrade(User sourceUser, User destinationUser, Game gameOfTrade, string description)
+        {
+            sourceUser = sourceUser ?? throw new ArgumentNullException(nameof(sourceUser));
+            destinationUser = destinationUser ?? throw new ArgumentNullException(nameof(destinationUser));
+            gameOfTrade = gameOfTrade ?? throw new ArgumentNullException(nameof(gameOfTrade));
+            this.tradeDescription = description ?? throw new ArgumentNullException(nameof(description));
+            this.tradeDate = DateTime.UtcNow;
+            this.tradeStatus = StatusPending;
+            this.acceptedBySourceUser = false;
+            this.acceptedByDestinationUser = false;
+            this.sourceUserItems = new List<Item>();
+            this.destinationUserItems = new List<Item>();
+            this.sourceUser = sourceUser;
+            this.destinationUser = destinationUser;
+            this.gameOfTrade = gameOfTrade;
+        }
+
+        /// <summary>
+        /// Gets the unique identifier of the trade.
+        /// </summary>
+        public int TradeId => this.tradeId;
+
+        /// <summary>
+        /// Gets the user who initiated the trade.
+        /// </summary>
+        public User SourceUser => this.sourceUser;
+
+        /// <summary>
+        /// Gets the user who received the trade.
+        /// </summary>
+        public User DestinationUser => this.destinationUser;
+
+        /// <summary>
+        /// Gets the game associated with the trade.
+        /// </summary>
+        public Game GameOfTrade => this.gameOfTrade;
+
+        /// <summary>
+        /// Gets the date and time when the trade was created.
+        /// </summary>
+        public DateTime TradeDate => this.tradeDate;
+
+        /// <summary>
+        /// Gets the description of the trade.
+        /// </summary>
+        public string TradeDescription => this.tradeDescription;
+
+        /// <summary>
+        /// Gets the current status of the trade.
+        /// </summary>
+        public string TradeStatus => this.tradeStatus;
+
+        /// <summary>
+        /// Gets a value indicating whether the source user accepted the trade.
+        /// </summary>
+        public bool AcceptedBySourceUser => this.acceptedBySourceUser;
+
+        /// <summary>
+        /// Gets a value indicating whether the destination user accepted the trade.
+        /// </summary>
+        public bool AcceptedByDestinationUser => this.acceptedByDestinationUser;
+
+        /// <summary>
+        /// Gets the list of items offered by the source user.
+        /// </summary>
+        public IReadOnlyList<Item> SourceUserItems => this.sourceUserItems;
+
+        /// <summary>
+        /// Gets the list of items offered by the destination user.
+        /// </summary>
+        public IReadOnlyList<Item> DestinationUserItems => this.destinationUserItems;
+
+        /// <summary>
+        /// Sets the unique identifier of the trade.
+        /// </summary>
+        /// <param name="tradeId">The ID to assign.</param>
+        public void SetTradeId(int tradeId)
+        {
+            this.tradeId = tradeId;
+        }
+
+        /// <summary>
+        /// Adds an item to the source user's list of offered items.
+        /// </summary>
+        /// <param name="item">The item to add.</param>
+        public void AddSourceUserItem(Item item)
+        {
+            if (item == null)
+            {
+                throw new ArgumentNullException(nameof(item));
+            }
+
+            this.sourceUserItems.Add(item);
+        }
+
+        /// <summary>
+        /// Adds an item to the destination user's list of offered items.
+        /// </summary>
+        /// <param name="item">The item to add.</param>
+        public void AddDestinationUserItem(Item item)
+        {
+            if (item == null)
+            {
+                throw new ArgumentNullException(nameof(item));
+            }
+
+            this.destinationUserItems.Add(item);
+        }
+
+        /// <summary>
+        /// Marks the trade as accepted by the source user.
+        /// </summary>
+        public void AcceptBySourceUser()
+        {
+            this.acceptedBySourceUser = true;
+            if (this.acceptedByDestinationUser)
+            {
+                this.tradeStatus = StatusCompleted;
+            }
+        }
+
+        /// <summary>
+        /// Marks the trade as accepted by the destination user.
+        /// </summary>
+        public void AcceptByDestinationUser()
+        {
+            this.acceptedByDestinationUser = true;
+            if (this.acceptedBySourceUser)
+            {
+                this.tradeStatus = StatusCompleted;
+            }
+        }
+
+        /// <summary>
+        /// Declines the trade and resets acceptance flags.
+        /// </summary>
+        public void DeclineTradeRequest()
+        {
+            this.tradeStatus = StatusDeclined;
+            this.acceptedBySourceUser = false;
+            this.acceptedByDestinationUser = false;
+        }
+
+        /// <summary>
+        /// Completes the trade by setting it as accepted by both users.
+        /// </summary>
+        public void MarkTradeAsCompleted()
+        {
+            this.tradeStatus = StatusCompleted;
+            this.acceptedBySourceUser = true;
+            this.acceptedByDestinationUser = true;
+        }
+    }
+}

--- a/Source/SteamHub/Models/ItemTrade.cs
+++ b/Source/SteamHub/Models/ItemTrade.cs
@@ -30,7 +30,7 @@
         /// <param name="sourceUser">The user initiating the trade.</param>
         /// <param name="destinationUser">The user receiving the trade.</param>
         /// <param name="gameOfTrade">The game the items belong to.</param>
-        /// <param name="description">The description of the trade.</param>
+        /// <param name="description">The Description of the trade.</param>
         public ItemTrade(User sourceUser, User destinationUser, Game gameOfTrade, string description)
         {
             sourceUser = sourceUser ?? throw new ArgumentNullException(nameof(sourceUser));
@@ -74,7 +74,7 @@
         public DateTime TradeDate => this.tradeDate;
 
         /// <summary>
-        /// Gets the description of the trade.
+        /// Gets the Description of the trade.
         /// </summary>
         public string TradeDescription => this.tradeDescription;
 

--- a/Source/SteamHub/Models/PointShopItem.cs
+++ b/Source/SteamHub/Models/PointShopItem.cs
@@ -1,0 +1,44 @@
+﻿// <copyright file="PointShopItem.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace SteamHub.Models
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+
+    public class PointShopItem
+    {
+        public PointShopItem(int itemIdentifier, string name, string description, string imagePath, double pointPrice, string itemType)
+        {
+            this.ItemIdentifier = itemIdentifier;
+            this.Name = name;
+            this.Description = description;
+            this.ImagePath = imagePath;
+            this.PointPrice = pointPrice;
+            this.ItemType = itemType;
+            this.IsActive = false;
+        }
+
+        public PointShopItem()
+        {
+        }
+
+        public int ItemIdentifier { get; set; }
+
+        public string Name { get; set; }
+
+        public string Description { get; set; }
+
+        public string ImagePath { get; set; }
+
+        public double PointPrice { get; set; }
+
+        public string ItemType { get; set; } // E.g., "ProfileBackground", "Avatar", "Emoticon", etc.
+
+        public bool IsActive { get; set; }
+    }
+}

--- a/Source/SteamHub/Models/PointShopTransaction.cs
+++ b/Source/SteamHub/Models/PointShopTransaction.cs
@@ -1,0 +1,34 @@
+﻿// <copyright file="PointShopTransaction.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace SteamHub.Models
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+
+    public class PointShopTransaction
+    {
+        public PointShopTransaction(int identifier, string itemName, double pointsSpent, string itemType)
+        {
+            this.Identifier = identifier;
+            this.ItemName = itemName;
+            this.PointsSpent = pointsSpent;
+            this.PurchaseDate = DateTime.Now;
+            this.ItemType = itemType;
+        }
+
+        public int Identifier { get; set; }
+
+        public string ItemName { get; set; }
+
+        public double PointsSpent { get; set; }
+
+        public DateTime PurchaseDate { get; set; }
+
+        public string ItemType { get; set; }
+    }
+}

--- a/Source/SteamHub/Models/Tag.cs
+++ b/Source/SteamHub/Models/Tag.cs
@@ -1,0 +1,23 @@
+﻿// <copyright file="Tag.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace SteamHub.Models
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+
+    public class Tag
+    {
+        public const int NOTCOMPUTED = -11111;
+
+        public int TagId { get; set; }
+
+        public string Tag_name { get; set; }
+
+        public int NumberOfUserGamesWithTag { get; set; }
+    }
+}

--- a/Source/SteamHub/Models/User.cs
+++ b/Source/SteamHub/Models/User.cs
@@ -1,0 +1,41 @@
+﻿// <copyright file="User.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace SteamHub.Models
+{
+    public class User
+    {
+        public User()
+        {
+        }
+
+        public User(int userIdentifier, string name, string email, float walletBalance, float pointsBalance, Role userRole)
+        {
+            this.UserId = userIdentifier;
+            this.UserName = name;
+            this.Email = email;
+            this.WalletBalance = walletBalance;
+            this.PointsBalance = pointsBalance;
+            this.UserRole = userRole;
+        }
+
+        public enum Role
+        {
+            Developer,
+            User,
+        }
+
+        public int UserId { get; set; }
+
+        public string UserName { get; set; }
+
+        public string Email { get; set; }
+
+        public float WalletBalance { get; set; }
+
+        public float PointsBalance { get; set; }
+
+        public Role UserRole { get; set; }
+    }
+}

--- a/Source/SteamHub/SteamHub.csproj
+++ b/Source/SteamHub/SteamHub.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
@@ -12,6 +12,9 @@
     <EnableMsixTooling>true</EnableMsixTooling>
     <Nullable>enable</Nullable>
   </PropertyGroup>
+  <ItemGroup>
+    <None Remove="gamefolders.json" />
+  </ItemGroup>
 
   <ItemGroup>
     <Content Include="Assets\SplashScreen.scale-200.png" />
@@ -21,6 +24,9 @@
     <Content Include="Assets\Square44x44Logo.targetsize-24_altform-unplated.png" />
     <Content Include="Assets\StoreLogo.png" />
     <Content Include="Assets\Wide310x150Logo.scale-200.png" />
+    <Content Include="gamefolders.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/SteamHub/Utils/GameFolderResolver.cs
+++ b/Source/SteamHub/Utils/GameFolderResolver.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+
+public static class GameFolderResolver
+{
+    private static readonly Dictionary<string, string> titleToFolder;
+
+    static GameFolderResolver()
+    {
+        string filePath = Path.Combine(AppContext.BaseDirectory, "gamefolders.json");
+        if (File.Exists(filePath))
+        {
+            string json = File.ReadAllText(filePath);
+            titleToFolder = JsonSerializer.Deserialize<Dictionary<string, string>>(json)!;
+        }
+        else
+        {
+            titleToFolder = new Dictionary<string, string>();
+        }
+    }
+
+    public static string GetFolderName(string gameTitle)
+    {
+        if (titleToFolder.TryGetValue(gameTitle.ToLower(), out string folderName))
+        {
+            return folderName;
+        }
+
+        // Fallback to normalized folder name
+        return gameTitle.ToLower().Replace(" ", "").Replace(":", "");
+    }
+}

--- a/Source/SteamHub/gamefolders.json
+++ b/Source/SteamHub/gamefolders.json
@@ -1,0 +1,5 @@
+﻿{
+  "counter-strike 2": "cs2",
+  "dota 2": "dota2",
+  "team fortress 2": "tf2"
+}


### PR DESCRIPTION
Feature Overview
Feature Name:
Merge Entities and Database from ArtAttack and CtrlAltElite into SteamHub

Description:
This feature integrates the entities and databases from the ArtAttack and CtrlAltElite projects into the SteamHub project. It standardizes models and updates the database schema.

Problem
Problem Addressed:
There were 2 projects each with its own entities' attributes and databases so they couldn't be merged until the attributes and tables were standardized.

Solution
How the feature was implemented:

Merged all relevant entities from both ArtAttack and CtrlAltElite into the SteamHub project.

Added new model classes to SteamHub.Models:

Game.cs

Item.cs

ItemTrade.cs

PointShopItem.cs

PointShopTransaction.cs

Tag.cs

User.cs

Created two new organizational folders under Data/:

Queries – Contains all the new/updated stored procedures, each in its own subfolder for clarity.

Schema – Contains Schema.sql, which holds the updated table definitions after merging both databases.

Updated or added necessary SQL procedures for CRUD and listing operations to support the new unified schema.

Key Files Affected
Models/Game.cs

Models/Item.cs

Models/ItemTrade.cs

Models/PointShopItem.cs

Models/PointShopTransaction.cs

Models/Tag.cs

Models/User.cs

Data/Queries/* (Multiple folders/files – one per procedure)

Data/Schema/Schema.sql

Also, there are a lot of files changed in the old projects because of the refactoring i made(in order to have the same attributes' names in all the projects so it is easier to transfer the other projects' components like repo service or views) in SteamHub.