### PR TITLE
Move the logic from the PointsShopPage View to the ModelView

### DIFF
--- a/Source/CtrlAltElite/Pages/PointsShopPage.xaml
+++ b/Source/CtrlAltElite/Pages/PointsShopPage.xaml
@@ -112,17 +112,18 @@
         </Grid>
 
         <!-- Simple Notification Bar -->
-        <Border Grid.Row="1" x:Name="NotificationBar" Visibility="Collapsed" Background="#75b022" Padding="15,10">
+        <Border Grid.Row="1" Visibility="{Binding NotificationVisibility}" Background="#75b022" Padding="15,10">
             <Grid>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*"/>
                     <ColumnDefinition Width="Auto"/>
                 </Grid.ColumnDefinitions>
-                <TextBlock x:Name="NotificationText" Text="Points Earned!" Foreground="White" FontWeight="SemiBold"/>
+                <TextBlock Text="{Binding NotificationMessage}" Foreground="White" FontWeight="SemiBold"/>
                 <Button Grid.Column="1" Content="✕" Click="CloseNotification_Click" 
-                        Background="Transparent" BorderBrush="Transparent" Foreground="White"/>
+                Background="Transparent" BorderBrush="Transparent" Foreground="White"/>
             </Grid>
         </Border>
+
 
         <!-- Shop Controls Grid -->
         <Grid Grid.Row="2" Margin="20,10,20,10">
@@ -213,7 +214,10 @@
         </Grid>
 
         <!-- Selected Item Details -->
-        <Grid Grid.Row="4" x:Name="ItemDetailPanel" Visibility="Collapsed" Background="#2a3a4a" Padding="20">
+        <Grid Grid.Row="4" x:Name="ItemDetailPanel" 
+      Visibility="{Binding ItemDetailVisibility}" 
+      Background="#2a3a4a" Padding="20">
+
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="Auto"/>
                 <ColumnDefinition Width="*"/>
@@ -223,17 +227,20 @@
 
             <!-- Item Image -->
             <Image
-                   Grid.Column="0" x:Name="SelectedItemImage" Width="100" Height="100" 
-                   Margin="0,0,20,0" Style="{StaticResource ItemImageStyle}" 
-                   ImageFailed="Image_ImageFailed"/>
+    Grid.Column="0"
+    Width="100" Height="100" 
+    Margin="0,0,20,0" 
+    Source="{Binding SelectedItemImageUri}"
+    Style="{StaticResource ItemImageStyle}" 
+    ImageFailed="Image_ImageFailed"/>
 
             <!-- Item Details -->
             <StackPanel Grid.Column="1">
-                <TextBlock x:Name="SelectedItemName" FontSize="18" FontWeight="Bold"/>
-                <TextBlock x:Name="SelectedItemType" Foreground="#aaaaaa" Margin="0,5,0,0"/>
-                <TextBlock x:Name="SelectedItemDescription" TextWrapping="Wrap" Margin="0,10,0,0"/>
+                <TextBlock Text="{Binding SelectedItemName}" FontSize="18" FontWeight="Bold"/>
+                <TextBlock Text="{Binding SelectedItemType}" Foreground="#aaaaaa" Margin="0,5,0,0"/>
+                <TextBlock Text="{Binding SelectedItemDescription}" TextWrapping="Wrap" Margin="0,10,0,0"/>
                 <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
-                    <TextBlock x:Name="SelectedItemPrice" FontWeight="Bold" Foreground="#75b022"/>
+                    <TextBlock Text="{Binding SelectedItemPrice}" FontWeight="Bold" Foreground="#75b022"/>
                 </StackPanel>
             </StackPanel>
 
@@ -255,7 +262,7 @@
         </Grid>
 
         <!-- Inventory Panel -->
-        <Grid Grid.Row="3" Grid.RowSpan="2" x:Name="InventoryPanel" Visibility="Collapsed" Background="#1a2233" Padding="20">
+        <Grid Grid.Row="3" Grid.RowSpan="2" x:Name="InventoryPanel" Visibility="{Binding InventoryPanelVisibility}" Background="#1a2233" Padding="20">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="*"/>
@@ -274,7 +281,8 @@
 
             <!-- Inventory Items -->
             <ScrollViewer Grid.Row="1" Margin="0,20,0,0">
-                <GridView x:Name="InventoryGridView" ItemsSource="{Binding UserItems}">
+                <GridView x:Name="InventoryGridView" ItemsSource="{Binding FilteredUserItems}">
+
                     <GridView.ItemTemplate>
                         <DataTemplate x:DataType="models:PointShopItem">
                             <Grid Width="200" Height="250" Margin="10" Background="#2a3a4a">
@@ -311,10 +319,11 @@
 
         <!-- Add Transaction History Panel -->
         <Grid x:Name="TransactionHistoryPanel" 
-              Visibility="Collapsed" 
-              Grid.RowSpan="5" 
-              Background="#1a2233E6" 
-              Padding="20">
+      Visibility="{Binding TransactionHistoryPanelVisibility}" 
+      Grid.RowSpan="5" 
+      Background="#1a2233E6" 
+      Padding="20">
+
             <Border Background="#2a3a4a" 
                     BorderBrush="#417eb5" 
                     BorderThickness="1" 

--- a/Source/CtrlAltElite/Pages/PointsShopPage.xaml.cs
+++ b/Source/CtrlAltElite/Pages/PointsShopPage.xaml.cs
@@ -50,9 +50,10 @@ namespace SteamStore.Pages
                 // Check for earned points
                 if (this.ViewModel.ShouldShowPointsEarnedNotification())
                 {
-                    this.ShowPointsEarnedNotification(this.ViewModel.GetPointsEarnedMessage());
+                    this.ViewModel.ShowNotification(this.ViewModel.GetPointsEarnedMessage());
                     this.ViewModel.ResetEarnedPoints();
                 }
+
             }
             catch (Exception exception)
             {
@@ -62,39 +63,21 @@ namespace SteamStore.Pages
 
         private PointShopViewModel ViewModel { get; set; }
 
-        public void ShowPointsEarnedNotification(string message)
-        {
-            this.NotificationText.Text = message;
-            this.NotificationBar.Visibility = Visibility.Visible;
-        }
-
         private void ItemsGridView_SelectionChanged(object itemsGridView, SelectionChangedEventArgs itemGridViewArguments)
         {
             if (this.ViewModel.HandleItemSelection())
             {
-                this.ItemDetailPanel.Visibility = Visibility.Visible;
+                this.ViewModel.ItemDetailVisibility = Visibility.Visible;
                 var details = this.ViewModel.GetSelectedItemDetails();
-
-                this.SelectedItemName.Text = details.Name;
-                this.SelectedItemType.Text = details.Type;
-                this.SelectedItemDescription.Text = details.Description;
-                this.SelectedItemPrice.Text = details.Price;
-
-                try
-                {
-                    if (!string.IsNullOrEmpty(details.ImageUri))
-                    {
-                        this.SelectedItemImage.Source = new BitmapImage(new Uri(details.ImageUri));
-                    }
-                }
-                catch (Exception exception)
-                {
-                    Debug.WriteLine($"Error loading image: {exception.Message}");
-                }
+                this.ViewModel.SelectedItemName = details.Name;
+                this.ViewModel.SelectedItemType = details.Type;
+                this.ViewModel.SelectedItemDescription = details.Description;
+                this.ViewModel.SelectedItemPrice = details.Price;
+                this.ViewModel.SelectedItemImageUri = details.ImageUri;
             }
             else
             {
-                this.ItemDetailPanel.Visibility = Visibility.Collapsed;
+                this.ViewModel.ItemDetailVisibility = Visibility.Collapsed;
             }
         }
 
@@ -104,25 +87,20 @@ namespace SteamStore.Pages
             this.ViewModel.ClearSelection();
         }
 
-        private async void PurchaseButton_Click(object purchaseButton, RoutedEventArgs purchaseClickEventArgument)
+        private async void PurchaseButton_Click(object sender, RoutedEventArgs e)
         {
-            bool success = await this.ViewModel.TryPurchaseSelectedItemAsync();
-
-            if (success)
-            {
-                this.ViewModel.ClearSelection();
-                this.ItemDetailPanel.Visibility = Visibility.Collapsed;
-            }
+            await this.ViewModel.TryPurchaseSelectedItemAsync();
         }
+
 
         private void ViewInventoryButton_Click(object viewInventoryButton, RoutedEventArgs viewInventoryClickEventArgument)
         {
-            this.InventoryPanel.Visibility = Visibility.Visible;
+            this.ViewModel.InventoryPanelVisibility = Visibility.Visible;
         }
 
         private void CloseInventoryButton_Click(object closeInventoryButton, RoutedEventArgs closeInventoryClickEventArgument)
         {
-            this.InventoryPanel.Visibility = Visibility.Collapsed;
+            this.ViewModel.InventoryPanelVisibility = Visibility.Collapsed;
         }
 
         private async void RemoveButtons_Click(object removeButton, RoutedEventArgs removeClickEventArgument)
@@ -152,23 +130,25 @@ namespace SteamStore.Pages
                 if (this.ViewModel != null)
                 {
                     this.ViewModel.FilterType = filterType;
+                    this.ViewModel.ApplyItemTypeFilter(filterType);
                 }
             }
         }
 
         private void CloseNotification_Click(object closeNotificationButton, RoutedEventArgs closeNotificationEventArgument)
         {
-            this.NotificationBar.Visibility = Visibility.Collapsed;
+            this.ViewModel.HideNotification();
+
         }
 
         private void ViewTransactionHistoryButton_Click(object viewTransactionHistoryButton, RoutedEventArgs viewTransactionHistoryClickEventArgument)
         {
-            this.TransactionHistoryPanel.Visibility = Visibility.Visible;
+            this.ViewModel.TransactionHistoryPanelVisibility = Visibility.Visible;
         }
 
         private void CloseTransactionHistoryButton_Click(object closeTransactionHistoryButton, RoutedEventArgs closeTransactionHistoryEventArgument)
         {
-            this.TransactionHistoryPanel.Visibility = Visibility.Collapsed;
+            this.ViewModel.TransactionHistoryPanelVisibility = Visibility.Collapsed;
         }
     }
 }

--- a/Source/CtrlAltElite/ViewModels/PointShopViewModel.cs
+++ b/Source/CtrlAltElite/ViewModels/PointShopViewModel.cs
@@ -11,6 +11,7 @@ namespace SteamStore.ViewModels
     using System.Runtime.CompilerServices;
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.UI.Xaml;
     using Microsoft.UI.Xaml.Controls;
     using SteamStore.Constants;
     using SteamStore.Data;
@@ -41,9 +42,171 @@ namespace SteamStore.ViewModels
         private CancellationTokenSource searchCancellationTokenSource;
         private int nextTransactionId = PointShopConstants.TRANSACTIONIDENTIFIER;
         private bool isDetailPanelVisible;
+        private string notificationMessage;
+        private Visibility notificationVisibility = Visibility.Collapsed;
+        private Visibility inventoryPanelVisibility = Visibility.Collapsed;
+        private Visibility itemDetailVisibility = Visibility.Collapsed;
+        private Visibility transactionHistoryPanelVisibility = Visibility.Collapsed;
+        private string selectedItemName;
+        private string selectedItemType;
+        private string selectedItemDescription;
+        private string selectedItemPrice;
+        private string selectedItemImageUri;
+        private ObservableCollection<PointShopItem> filteredUserItems;
+        public string SelectedItemName
+        {
+            get => this.selectedItemName;
+            set
+            {
+                if (this.selectedItemName != value)
+                {
+                    this.selectedItemName = value;
+                    this.OnPropertyChanged(nameof(this.SelectedItemName));
+                }
+            }
+        }
 
-         // public PointShopViewModel(User currentUser, IDataLink dataLink)
-         // {
+        public string SelectedItemType
+        {
+            get => this.selectedItemType;
+            set
+            {
+                if (this.selectedItemType != value)
+                {
+                    this.selectedItemType = value;
+                    this.OnPropertyChanged(nameof(this.SelectedItemType));
+                }
+            }
+        }
+
+        public string SelectedItemDescription
+        {
+            get => this.selectedItemDescription;
+            set
+            {
+                if (this.selectedItemDescription != value)
+                {
+                    this.selectedItemDescription = value;
+                    this.OnPropertyChanged(nameof(this.SelectedItemDescription));
+                }
+            }
+        }
+
+        public string SelectedItemPrice
+        {
+            get => this.selectedItemPrice;
+            set
+            {
+                if (this.selectedItemPrice != value)
+                {
+                    this.selectedItemPrice = value;
+                    this.OnPropertyChanged(nameof(this.SelectedItemPrice));
+                }
+            }
+        }
+
+        public string SelectedItemImageUri
+        {
+            get => this.selectedItemImageUri;
+            set
+            {
+                if (this.selectedItemImageUri != value)
+                {
+                    this.selectedItemImageUri = value;
+                    this.OnPropertyChanged(nameof(this.SelectedItemImageUri));
+                }
+            }
+        }
+
+
+        public string NotificationMessage
+        {
+            get => this.notificationMessage;
+            set
+            {
+                this.notificationMessage = value;
+                this.OnPropertyChanged(nameof(this.NotificationMessage));
+            }
+        }
+        public Visibility NotificationVisibility
+        {
+            get => this.notificationVisibility;
+            set
+            {
+                this.notificationVisibility = value;
+                this.OnPropertyChanged(nameof(this.NotificationVisibility));
+            }
+        }
+
+        public Visibility ItemDetailVisibility
+        {
+            get => this.itemDetailVisibility;
+            set
+            {
+                this.itemDetailVisibility = value;
+                this.OnPropertyChanged();
+            }
+        }
+
+        public Visibility InventoryPanelVisibility
+        {
+            get => this.inventoryPanelVisibility;
+            set
+            {
+                this.inventoryPanelVisibility = value;
+                this.OnPropertyChanged();
+            }
+        }
+
+        public Visibility TransactionHistoryPanelVisibility
+        {
+            get => this.transactionHistoryPanelVisibility;
+            set
+            {
+                this.transactionHistoryPanelVisibility = value;
+                this.OnPropertyChanged();
+            }
+        }
+
+        public ObservableCollection<PointShopItem> FilteredUserItems
+        {
+            get => this.filteredUserItems;
+            set
+            {
+                this.filteredUserItems = value;
+                this.OnPropertyChanged();
+            }
+        }
+
+        public void ShowNotification(string message)
+        {
+            NotificationMessage = message;
+            NotificationVisibility = Visibility.Visible;
+        }
+
+        public void HideNotification()
+        {
+            NotificationVisibility = Visibility.Collapsed;
+        }
+
+        public void ApplyItemTypeFilter(string itemType)
+        {
+            if (itemType == "All")
+            {
+                this.FilteredUserItems = new ObservableCollection<PointShopItem>(this.UserItems);
+            }
+            else
+            {
+                var filteredItems = this.UserItems.Where(item => item.ItemType == itemType);
+                this.FilteredUserItems = new ObservableCollection<PointShopItem>(filteredItems);
+            }
+        }
+
+
+
+
+        // public PointShopViewModel(User currentUser, IDataLink dataLink)
+        // {
         //    // Store the current user reference
         //    this.user = currentUser;
 
@@ -69,6 +232,8 @@ namespace SteamStore.ViewModels
             this.ShopItems = new ObservableCollection<PointShopItem>();
             this.UserItems = new ObservableCollection<PointShopItem>();
             this.TransactionHistory = new ObservableCollection<PointShopTransaction>();
+           
+
 
             // Load initial data
             this.LoadItems();
@@ -77,7 +242,7 @@ namespace SteamStore.ViewModels
 
         public event PropertyChangedEventHandler PropertyChanged;
 
-        public string SelectedItemImageUri { get; private set; }
+        //public string SelectedItemImageUri { get; private set; }
 
         public bool IsDetailPanelVisible
         {
@@ -230,6 +395,7 @@ namespace SteamStore.ViewModels
                 {
                     this.UserItems.Add(item);
                 }
+                this.FilteredUserItems = new ObservableCollection<PointShopItem>(this.UserItems);
             }
             catch (Exception exception)
             {
@@ -330,6 +496,10 @@ namespace SteamStore.ViewModels
         {
             if (this.SelectedItem != null)
             {
+                this.SelectedItemName = this.SelectedItem.Name;
+                this.SelectedItemType = this.SelectedItem.ItemType;
+                this.SelectedItemDescription = this.SelectedItem.Description;
+                this.SelectedItemPrice = this.SelectedItem.PointPrice.ToString();
                 this.SelectedItemImageUri = this.SelectedItem.ImagePath;
                 this.IsDetailPanelVisible = true;
             }
@@ -338,10 +508,9 @@ namespace SteamStore.ViewModels
                 this.IsDetailPanelVisible = false;
             }
 
-            this.OnPropertyChanged(nameof(this.SelectedItemImageUri));
-            this.OnPropertyChanged(nameof(this.IsDetailPanelVisible));
             return this.IsDetailPanelVisible;
         }
+
 
         public void ClearSelection()
         {
@@ -373,12 +542,12 @@ namespace SteamStore.ViewModels
             }
         }
 
-        public async Task<bool> TryPurchaseSelectedItemAsync()
+        public async Task TryPurchaseSelectedItemAsync()
         {
             if (this.SelectedItem == null)
             {
                 await this.ShowDialog("Error", "No item selected");
-                return false;
+                return;
             }
 
             string itemName = this.SelectedItem.Name;
@@ -400,19 +569,28 @@ namespace SteamStore.ViewModels
                     this.LoadUserItems();
                     this.LoadItems();
 
-                    await this.ShowDialog("Congrats!", $"You have successfully purchased {itemName}. Check your inventory to view it.");
-                    return true;
-                }
+                   
+                    this.ClearSelection();
+                    this.ItemDetailVisibility = Visibility.Collapsed;
 
-                await this.ShowDialog("Error", "Purchase failed. Please try again.");
-                return false;
+                  
+                    this.ApplyItemTypeFilter(this.FilterType);
+
+                 
+                    this.ShowNotification($"You have successfully purchased {itemName}. Check your inventory!");
+                }
+                else
+                {
+                    
+                    this.ShowNotification("Purchase failed. Please try again.");
+                }
             }
             catch (Exception exception)
             {
-                await this.ShowDialog("Error", $"Purchase Failed: {exception.Message}");
-                return false;
+                this.ShowNotification($"Purchase failed: {exception.Message}");
             }
         }
+
 
         public async Task ToggleActivationForItemWithMessage(int itemId)
         {


### PR DESCRIPTION
Feature Overview
Feature Name:
Transfer Purchase, Notification, Visibility, Filtering, and Item Detail Logic into ViewModel

Description:
This PR moves all important UI state management from the PointsShopPage code-behind into PointShopViewModel for clean MVVM separation. Now, the UI only binds to ViewModel properties and triggers ViewModel commands/methods. Problem
Problem Addressed:

Logic for purchasing, showing notifications, filtering inventory, and controlling panel visibility was previously handled inside the page code-behind (PointsShopPage.xaml.cs). Solution
How the feature was implemented:

Notification Logic was moved entirely to the ViewModel. UI no longer manages dialogs; notifications are triggered by the ViewModel after actions.

Panel Visibility for Inventory, Item Detail, and Transaction History is now controlled by ViewModel properties (InventoryPanelVisibility, ItemDetailVisibility, TransactionHistoryPanelVisibility).

Filtering Logic (ApplyItemTypeFilter, FilterType) was relocated to ViewModel, using a FilteredUserItems collection.

Item Detail Content (Selected Item's Name, Type, Description, Price, ImageUri) is managed via ViewModel binding instead of direct setting in UI. Purchase Logic (TryPurchaseSelectedItemAsync) was refactored:

ViewModel clears the selection and updates inventory internally after purchase.

UI no longer needs to interpret purchase results — just triggers the action. Key files affected:

PointsShopPage.xaml.cs

PointShopViewModel.cs

PointsShopPage.xaml