### PR TITLE
Moved the logic from the TradeView to the TradeViewModel

### DIFF
--- a/Source/ArtAttack/Constants/TradeDialogStrings.cs
+++ b/Source/ArtAttack/Constants/TradeDialogStrings.cs
@@ -1,0 +1,77 @@
+﻿// <copyright file="TradeDialogStrings.cs" company="PlaceholderCompany">
+// Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+
+namespace Steampunks.Constants
+{
+    /// <summary>
+    /// Contains constant strings used for trade dialog titles, messages and button texts.
+    /// </summary>
+    public static class TradeDialogStrings
+    {
+        /// <summary>
+        /// Title shown when a trade cannot be sent.
+        /// </summary>
+        public const string CannotSendTradeTitle = "Cannot Send Trade";
+
+        /// <summary>
+        /// Message shown when a trade cannot be sent.
+        /// </summary>
+        public const string CannotSendTradeMessage = "Please select a user to trade with, add items to trade, and provide a trade description.";
+
+        /// <summary>
+        /// Title shown when confirming a trade.
+        /// </summary>
+        public const string ConfirmTradeTitle = "Confirm Trade";
+
+        /// <summary>
+        /// Message shown when confirming a trade.
+        /// </summary>
+        public const string ConfirmTradeMessage = "Are you sure you want to send this trade offer?";
+
+        /// <summary>
+        /// Title shown when accepting a trade.
+        /// </summary>
+        public const string AcceptTradeTitle = "Accept Trade";
+
+        /// <summary>
+        /// Message shown when accepting a trade.
+        /// </summary>
+        public const string AcceptTradeMessage = "Are you sure you want to accept this trade?";
+
+        /// <summary>
+        /// Title shown when declining a trade.
+        /// </summary>
+        public const string DeclineTradeTitle = "Decline Trade";
+
+        /// <summary>
+        /// Message shown when declining a trade.
+        /// </summary>
+        public const string DeclineTradeMessage = "Are you sure you want to decline this trade?";
+
+        /// <summary>
+        /// Text for the Send button.
+        /// </summary>
+        public const string SendButtonText = "Send";
+
+        /// <summary>
+        /// Text for the Accept button.
+        /// </summary>
+        public const string AcceptButtonText = "Accept";
+
+        /// <summary>
+        /// Text for the Decline button.
+        /// </summary>
+        public const string DeclineButtonText = "Decline";
+
+        /// <summary>
+        /// Text for the Cancel button.
+        /// </summary>
+        public const string CancelButtonText = "Cancel";
+
+        /// <summary>
+        /// Text for the OK button.
+        /// </summary>
+        public const string OkButtonText = "OK";
+    }
+}

--- a/Source/ArtAttack/ViewModels/ITradeViewModel.cs
+++ b/Source/ArtAttack/ViewModels/ITradeViewModel.cs
@@ -8,6 +8,7 @@ namespace Steampunks.ViewModels
     using System.Collections.ObjectModel;
     using System.ComponentModel;
     using System.Threading.Tasks;
+    using Microsoft.UI.Xaml;
     using Steampunks.Domain.Entities;
 
     /// <summary>
@@ -200,5 +201,40 @@ namespace Steampunks.ViewModels
         /// </summary>
         /// <param name="item">The item in the selected list.</param>
         void RemoveSourceItem(Item item);
+
+        /// <summary>
+        /// Attempts to send a trade offer after validating input and confirming with the user.
+        /// </summary>
+        /// <param name="root">The XamlRoot of the page where the dialog should be displayed.</param>
+        /// <returns>A task representing the asynchronous operation.</returns>
+        Task TrySendTradeAsync(XamlRoot root);
+
+        /// <summary>
+        /// Attempts to accept a given trade after displaying a confirmation dialog to the user.
+        /// </summary>
+        /// <param name="trade">The trade to accept.</param>
+        /// <param name="root">The XamlRoot used to display the confirmation dialog in the UI.</param>
+        /// <returns>A task representing the asynchronous operation.</returns>
+        Task TryAcceptTradeAsync(ItemTrade trade, XamlRoot root);
+
+        /// <summary>
+        /// Attempts to decline a given trade after displaying a confirmation dialog to the user.
+        /// </summary>
+        /// <param name="trade">The trade to decline.</param>
+        /// <param name="root">The XamlRoot used to display the confirmation dialog in the UI.</param>
+        /// <returns>A task representing the asynchronous operation.</returns>
+        Task TryDeclineTradeAsync(ItemTrade trade, XamlRoot root);
+
+        /// <summary>
+        /// Adds multiple selected source items from the user's inventory to the current trade offer.
+        /// </summary>
+        /// <param name="selectedItems">The list of items selected by the user to be added to the source side of the trade.</param>
+        void AddSelectedSourceItems(IList<object> selectedItems);
+
+        /// <summary>
+        /// Adds multiple selected destination items from the trading partner's inventory to the current trade offer.
+        /// </summary>
+        /// <param name="selectedItems">The list of items selected by the user to be added to the destination side of the trade.</param>
+        void AddSelectedDestinationItems(IList<object> selectedItems);
     }
 }

--- a/Source/ArtAttack/Views/TradeView.xaml.cs
+++ b/Source/ArtAttack/Views/TradeView.xaml.cs
@@ -17,26 +17,6 @@ namespace Steampunks.Views
     /// </summary>
     public sealed partial class TradeView : Page
     {
-        private const string CannotSendTradeTitle = "Cannot Send Trade";
-        private const string CannotSendTradeMessage = "Please select a user to trade with, add items to trade, and provide a trade description.";
-
-        private const string ConfirmTradeTitle = "Confirm Trade";
-        private const string ConfirmTradeMessage = "Are you sure you want to send this trade offer?";
-
-        private const string AcceptTradeTitle = "Accept Trade";
-        private const string AcceptTradeMessage = "Are you sure you want to accept this trade?";
-
-        private const string DeclineTradeTitle = "Decline Trade";
-        private const string DeclineTradeMessage = "Are you sure you want to decline this trade?";
-
-        private const string PrimaryButtonSendText = "Send";
-        private const string PrimaryButtonAcceptText = "Accept";
-        private const string PrimaryButtonDeclineText = "Decline";
-        private const string CloseButtonCancelText = "Cancel";
-        private const string CloseButtonOkText = "OK";
-
-        private const int MinimumSelectedItemsCount = 1;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="TradeView"/> class.
         /// </summary>
@@ -66,18 +46,8 @@ namespace Steampunks.Views
         /// </summary>
         private void OnAddSourceItemButtonClicked(object sender, RoutedEventArgs eventArguments)
         {
-            if (this.SourceItemsListView.SelectedItems.Count >= MinimumSelectedItemsCount)
-            {
-                foreach (var selectedObject in this.SourceItemsListView.SelectedItems)
-                {
-                    if (selectedObject is Item selectedItem)
-                    {
-                        this.ViewModel.AddSourceItem(selectedItem);
-                    }
-                }
-
-                this.SourceItemsListView.SelectedItems.Clear();
-            }
+            this.ViewModel.AddSelectedSourceItems(this.SourceItemsListView.SelectedItems);
+            this.SourceItemsListView.SelectedItems.Clear();
         }
 
         /// <summary>
@@ -85,18 +55,8 @@ namespace Steampunks.Views
         /// </summary>
         private void OnAddDestinationItemButtonClicked(object sender, RoutedEventArgs eventArguments)
         {
-            if (this.DestinationItemsListView.SelectedItems.Count >= MinimumSelectedItemsCount)
-            {
-                foreach (var selectedObject in this.DestinationItemsListView.SelectedItems)
-                {
-                    if (selectedObject is Item selectedItem)
-                    {
-                        this.ViewModel.AddDestinationItem(selectedItem);
-                    }
-                }
-
-                this.DestinationItemsListView.SelectedItems.Clear();
-            }
+            this.ViewModel.AddSelectedDestinationItems(this.DestinationItemsListView.SelectedItems);
+            this.DestinationItemsListView.SelectedItems.Clear();
         }
 
         /// <summary>
@@ -126,35 +86,7 @@ namespace Steampunks.Views
         /// </summary>
         private async void OnSendTradeOfferButtonClicked(object sender, RoutedEventArgs eventArguments)
         {
-            if (!this.ViewModel.CanSendTradeOffer)
-            {
-                var cannotSendTradeDialog = new ContentDialog
-                {
-                    Title = CannotSendTradeTitle,
-                    Content = CannotSendTradeMessage,
-                    CloseButtonText = CloseButtonOkText,
-                    XamlRoot = this.XamlRoot,
-                };
-
-                await cannotSendTradeDialog.ShowAsync();
-                return;
-            }
-
-            var confirmSendTradeDialog = new ContentDialog
-            {
-                Title = ConfirmTradeTitle,
-                Content = ConfirmTradeMessage,
-                PrimaryButtonText = PrimaryButtonSendText,
-                CloseButtonText = CloseButtonCancelText,
-                XamlRoot = this.XamlRoot,
-            };
-
-            var userDialogResult = await confirmSendTradeDialog.ShowAsync();
-
-            if (userDialogResult == ContentDialogResult.Primary)
-            {
-                await this.ViewModel.CreateTradeOffer();
-            }
+            await this.ViewModel.TrySendTradeAsync(this.XamlRoot);
         }
 
         /// <summary>
@@ -164,21 +96,7 @@ namespace Steampunks.Views
         {
             if (sender is Button clickedButton && clickedButton.Tag is ItemTrade tradeToAccept)
             {
-                var confirmAcceptTradeDialog = new ContentDialog
-                {
-                    Title = AcceptTradeTitle,
-                    Content = AcceptTradeMessage,
-                    PrimaryButtonText = PrimaryButtonAcceptText,
-                    CloseButtonText = CloseButtonCancelText,
-                    XamlRoot = this.XamlRoot,
-                };
-
-                var userDialogResult = await confirmAcceptTradeDialog.ShowAsync();
-
-                if (userDialogResult == ContentDialogResult.Primary)
-                {
-                    this.ViewModel.AcceptTrade(tradeToAccept);
-                }
+                await this.ViewModel.TryAcceptTradeAsync(tradeToAccept, this.XamlRoot);
             }
         }
 
@@ -189,21 +107,7 @@ namespace Steampunks.Views
         {
             if (sender is Button clickedButton && clickedButton.Tag is ItemTrade tradeToDecline)
             {
-                var confirmDeclineTradeDialog = new ContentDialog
-                {
-                    Title = DeclineTradeTitle,
-                    Content = DeclineTradeMessage,
-                    PrimaryButtonText = PrimaryButtonDeclineText,
-                    CloseButtonText = CloseButtonCancelText,
-                    XamlRoot = this.XamlRoot,
-                };
-
-                var userDialogResult = await confirmDeclineTradeDialog.ShowAsync();
-
-                if (userDialogResult == ContentDialogResult.Primary)
-                {
-                    await this.ViewModel.DeclineTradeAsync(tradeToDecline);
-                }
+                await this.ViewModel.TryDeclineTradeAsync(tradeToDecline, this.XamlRoot);
             }
         }
     }


### PR DESCRIPTION
The TradeView page contained business logic inside the code-behind, specifically in the dialog creation and validation steps for sending, accepting, and declining trades. I have moved this logic into the TradeViewModel by adding the methods TrySendTradeAsync, TryAcceptTradeAsync, and TryDeclineTradeAsync, which handle trade validation, dialog construction, and result processing. The View now only triggers these methods from button click handlers. Additionally, all dialog titles, messages, and button texts were extracted into a separate TradeDialogStrings class located in a new Constants folder.