### PR TITLE
created ItemTradeDetail entity

### DIFF
--- a/Source/SteamHub.Api/Context/DataContext.cs
+++ b/Source/SteamHub.Api/Context/DataContext.cs
@@ -31,6 +31,7 @@ namespace SteamHub.Api.Context
 
         public DbSet<StoreTransaction> StoreTransactions { get; set; }
         public DbSet<ItemTrade> ItemTrades { get; set; }
+        public DbSet<ItemTradeDetail> ItemTradeDetails { get; set; }
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
@@ -485,6 +486,31 @@ namespace SteamHub.Api.Context
             };
 
             builder.Entity<ItemTrade>().HasData(itemTradesSeed);
+
+            builder.Entity<ItemTradeDetail>()
+            .HasKey(itd => new { itd.TradeId, itd.ItemId });
+
+            builder.Entity<ItemTradeDetail>()
+                .HasOne(itd => itd.ItemTrade)
+                .WithMany(it => it.ItemTradeDetails)
+                .HasForeignKey(itd => itd.TradeId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            builder.Entity<ItemTradeDetail>()
+                .HasOne(itd => itd.Item)
+                .WithMany(i => i.ItemTradeDetails)
+                .HasForeignKey(itd => itd.ItemId)
+                .OnDelete(DeleteBehavior.Restrict);
+
+            var itemTradeDetailsSeed = new List<ItemTradeDetail>
+            { 
+                new ItemTradeDetail { TradeId = 1, ItemId = 1, IsSourceUserItem = true },
+               // new ItemTradeDetail { TradeId = 1, ItemId = 1, IsSourceUserItem = false },
+                new ItemTradeDetail { TradeId = 2, ItemId = 2, IsSourceUserItem = false },
+               // new ItemTradeDetail { TradeId = 2, ItemId = 2, IsSourceUserItem = true }
+            };
+
+            builder.Entity<ItemTradeDetail>().HasData(itemTradeDetailsSeed);
         }
     }
 }

--- a/Source/SteamHub.Api/Context/Repositories/IItemTradeDetailRepository.cs
+++ b/Source/SteamHub.Api/Context/Repositories/IItemTradeDetailRepository.cs
@@ -1,0 +1,10 @@
+﻿using SteamHub.Api.Models.ItemTradeDetails;
+
+namespace SteamHub.Api.Context.Repositories;
+public interface IItemTradeDetailRepository
+{
+    Task<GetItemTradeDetailsResponse?> GetItemTradeDetailsAsync();
+    Task<ItemTradeDetailResponse?> GetItemTradeDetailAsync(int tradeId, int itemId);
+    Task<CreateItemTradeDetailResponse> CreateItemTradeDetailAsync(CreateItemTradeDetailRequest request);
+    Task DeleteItemTradeDetailAsync(int tradeId, int itemId);
+}

--- a/Source/SteamHub.Api/Context/Repositories/ItemTradeDetailRepository.cs
+++ b/Source/SteamHub.Api/Context/Repositories/ItemTradeDetailRepository.cs
@@ -1,0 +1,77 @@
+﻿using Microsoft.EntityFrameworkCore;
+using SteamHub.Api.Entities;
+using SteamHub.Api.Models.ItemTradeDetails;
+
+namespace SteamHub.Api.Context.Repositories;
+public class ItemTradeDetailRepository : IItemTradeDetailRepository
+{
+    private readonly DataContext _context;
+
+    public ItemTradeDetailRepository(DataContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<GetItemTradeDetailsResponse?> GetItemTradeDetailsAsync()
+    {
+        var details = await _context.ItemTradeDetails
+            .Select(d => new ItemTradeDetailResponse
+            {
+                TradeId = d.TradeId,
+                ItemId = d.ItemId,
+                IsSourceUserItem = d.IsSourceUserItem
+            })
+            .ToListAsync();
+
+        return new GetItemTradeDetailsResponse
+        {
+            ItemTradeDetails = details
+        };
+    }
+
+    public async Task<ItemTradeDetailResponse?> GetItemTradeDetailAsync(int tradeId, int itemId)
+    {
+        var result = await _context.ItemTradeDetails
+            .Where(d => d.TradeId == tradeId && d.ItemId == itemId)
+            .Select(d => new ItemTradeDetailResponse
+            {
+                TradeId = d.TradeId,
+                ItemId = d.ItemId,
+                IsSourceUserItem = d.IsSourceUserItem
+            })
+            .SingleOrDefaultAsync();
+
+        return result;
+    }
+
+    public async Task<CreateItemTradeDetailResponse> CreateItemTradeDetailAsync(CreateItemTradeDetailRequest request)
+    {
+        var newDetail = new ItemTradeDetail
+        {
+            TradeId = request.TradeId,
+            ItemId = request.ItemId,
+            IsSourceUserItem = request.IsSourceUserItem
+        };
+
+        await _context.ItemTradeDetails.AddAsync(newDetail);
+        await _context.SaveChangesAsync();
+
+        return new CreateItemTradeDetailResponse
+        {
+            TradeId = newDetail.TradeId,
+            ItemId = newDetail.ItemId
+        };
+    }
+
+    public async Task DeleteItemTradeDetailAsync(int tradeId, int itemId)
+    {
+        var detail = await _context.ItemTradeDetails.FindAsync(tradeId, itemId);
+        if (detail == null)
+        {
+            throw new Exception("ItemTradeDetail not found");
+        }
+
+        _context.ItemTradeDetails.Remove(detail);
+        await _context.SaveChangesAsync();
+    }
+}

--- a/Source/SteamHub.Api/Controllers/ItemTradeDetailsController.cs
+++ b/Source/SteamHub.Api/Controllers/ItemTradeDetailsController.cs
@@ -1,0 +1,60 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using SteamHub.Api.Context.Repositories;
+using SteamHub.Api.Models.ItemTradeDetails;
+
+namespace SteamHub.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class ItemTradeDetailsController : ControllerBase
+{
+    private readonly IItemTradeDetailRepository _repository;
+
+    public ItemTradeDetailsController(IItemTradeDetailRepository repository)
+    {
+        _repository = repository;
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> GetAll()
+    {
+        var result = await _repository.GetItemTradeDetailsAsync();
+        return Ok(result);
+    }
+
+    [HttpGet("{tradeId}/{itemId}")]
+    public async Task<IActionResult> GetById(int tradeId, int itemId)
+    {
+        var result = await _repository.GetItemTradeDetailAsync(tradeId, itemId);
+        return result is null ? NotFound() : Ok(result);
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> Create([FromBody] CreateItemTradeDetailRequest request)
+    {
+        try
+        {
+            var created = await _repository.CreateItemTradeDetailAsync(request);
+            return Ok(created);
+        }
+        catch (Exception ex)
+        {
+            return BadRequest($"An error occurred: {ex.Message}");
+        }
+    }
+
+    [HttpDelete("{tradeId}/{itemId}")]
+    public async Task<IActionResult> Delete(int tradeId, int itemId)
+    {
+        try
+        {
+            await _repository.DeleteItemTradeDetailAsync(tradeId, itemId);
+        }
+        catch (Exception ex)
+        {
+            return BadRequest($"An error occurred: {ex.Message}");
+        }
+
+        return NoContent();
+    }
+}

--- a/Source/SteamHub.Api/Entities/Item.cs
+++ b/Source/SteamHub.Api/Entities/Item.cs
@@ -23,6 +23,9 @@
 
         public string ImagePath { get; set; } = default!;
 
+        public IList<ItemTradeDetail> ItemTradeDetails { get; set; }
+
+
         public Item() { }
 
         public Item(string itemName, int correspondingGameId, float price, string description)

--- a/Source/SteamHub.Api/Entities/ItemTrade.cs
+++ b/Source/SteamHub.Api/Entities/ItemTrade.cs
@@ -30,5 +30,8 @@
         public bool AcceptedBySourceUser { get; set; } = false;
 
         public bool AcceptedByDestinationUser { get; set; } = false;
+
+        public IList<ItemTradeDetail> ItemTradeDetails { get; set; }
+
     }
 }

--- a/Source/SteamHub.Api/Entities/ItemTradeDetails.cs
+++ b/Source/SteamHub.Api/Entities/ItemTradeDetails.cs
@@ -1,0 +1,11 @@
+﻿namespace SteamHub.Api.Entities;
+
+public class ItemTradeDetail
+{
+    public int TradeId { get; set; }
+    public int ItemId { get; set; }
+    public bool IsSourceUserItem { get; set; }
+
+    public ItemTrade ItemTrade { get; set; }
+    public Item Item { get; set; }
+}

--- a/Source/SteamHub.Api/Migrations/20250430132457_Mainmigration.Designer.cs
+++ b/Source/SteamHub.Api/Migrations/20250430132457_Mainmigration.Designer.cs
@@ -12,8 +12,8 @@ using SteamHub.Api.Context;
 namespace SteamHub.Api.Migrations
 {
     [DbContext(typeof(DataContext))]
-    [Migration("20250429204724_MainMigration")]
-    partial class MainMigration
+    [Migration("20250430132457_Mainmigration")]
+    partial class Mainmigration
     {
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
@@ -395,6 +395,38 @@ namespace SteamHub.Api.Migrations
                             TradeDate = new DateTime(2025, 4, 28, 0, 0, 0, 0, DateTimeKind.Unspecified),
                             TradeDescription = "Trade 2: User3 offers Game2 to User4",
                             TradeStatus = 0
+                        });
+                });
+
+            modelBuilder.Entity("SteamHub.Api.Entities.ItemTradeDetail", b =>
+                {
+                    b.Property<int>("TradeId")
+                        .HasColumnType("int");
+
+                    b.Property<int>("ItemId")
+                        .HasColumnType("int");
+
+                    b.Property<bool>("IsSourceUserItem")
+                        .HasColumnType("bit");
+
+                    b.HasKey("TradeId", "ItemId");
+
+                    b.HasIndex("ItemId");
+
+                    b.ToTable("ItemTradeDetails");
+
+                    b.HasData(
+                        new
+                        {
+                            TradeId = 1,
+                            ItemId = 1,
+                            IsSourceUserItem = true
+                        },
+                        new
+                        {
+                            TradeId = 2,
+                            ItemId = 2,
+                            IsSourceUserItem = false
                         });
                 });
 
@@ -900,6 +932,25 @@ namespace SteamHub.Api.Migrations
                     b.Navigation("SourceUser");
                 });
 
+            modelBuilder.Entity("SteamHub.Api.Entities.ItemTradeDetail", b =>
+                {
+                    b.HasOne("SteamHub.Api.Entities.Item", "Item")
+                        .WithMany("ItemTradeDetails")
+                        .HasForeignKey("ItemId")
+                        .OnDelete(DeleteBehavior.Restrict)
+                        .IsRequired();
+
+                    b.HasOne("SteamHub.Api.Entities.ItemTrade", "ItemTrade")
+                        .WithMany("ItemTradeDetails")
+                        .HasForeignKey("TradeId")
+                        .OnDelete(DeleteBehavior.Restrict)
+                        .IsRequired();
+
+                    b.Navigation("Item");
+
+                    b.Navigation("ItemTrade");
+                });
+
             modelBuilder.Entity("SteamHub.Api.Entities.StoreTransaction", b =>
                 {
                     b.HasOne("SteamHub.Api.Entities.Game", "Game")
@@ -952,6 +1003,16 @@ namespace SteamHub.Api.Migrations
             modelBuilder.Entity("SteamHub.Api.Entities.Game", b =>
                 {
                     b.Navigation("StoreTransactions");
+                });
+
+            modelBuilder.Entity("SteamHub.Api.Entities.Item", b =>
+                {
+                    b.Navigation("ItemTradeDetails");
+                });
+
+            modelBuilder.Entity("SteamHub.Api.Entities.ItemTrade", b =>
+                {
+                    b.Navigation("ItemTradeDetails");
                 });
 
             modelBuilder.Entity("SteamHub.Api.Entities.PointShopItem", b =>

--- a/Source/SteamHub.Api/Migrations/20250430132457_Mainmigration.cs
+++ b/Source/SteamHub.Api/Migrations/20250430132457_Mainmigration.cs
@@ -8,7 +8,7 @@ using Microsoft.EntityFrameworkCore.Migrations;
 namespace SteamHub.Api.Migrations
 {
     /// <inheritdoc />
-    public partial class MainMigration : Migration
+    public partial class Mainmigration : Migration
     {
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
@@ -261,6 +261,31 @@ namespace SteamHub.Api.Migrations
                         onDelete: ReferentialAction.Restrict);
                 });
 
+            migrationBuilder.CreateTable(
+                name: "ItemTradeDetails",
+                columns: table => new
+                {
+                    TradeId = table.Column<int>(type: "int", nullable: false),
+                    ItemId = table.Column<int>(type: "int", nullable: false),
+                    IsSourceUserItem = table.Column<bool>(type: "bit", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ItemTradeDetails", x => new { x.TradeId, x.ItemId });
+                    table.ForeignKey(
+                        name: "FK_ItemTradeDetails_ItemTrades_TradeId",
+                        column: x => x.TradeId,
+                        principalTable: "ItemTrades",
+                        principalColumn: "TradeId",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_ItemTradeDetails_Items_ItemId",
+                        column: x => x.ItemId,
+                        principalTable: "Items",
+                        principalColumn: "ItemId",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
             migrationBuilder.InsertData(
                 table: "GameStatus",
                 columns: new[] { "Id", "Name" },
@@ -402,6 +427,15 @@ namespace SteamHub.Api.Migrations
                     { 2, 59.99f, new DateTime(2025, 4, 27, 14, 30, 0, 0, DateTimeKind.Unspecified), 2, 2, false }
                 });
 
+            migrationBuilder.InsertData(
+                table: "ItemTradeDetails",
+                columns: new[] { "ItemId", "TradeId", "IsSourceUserItem" },
+                values: new object[,]
+                {
+                    { 1, 1, true },
+                    { 2, 2, false }
+                });
+
             migrationBuilder.CreateIndex(
                 name: "IX_Games_PublisherUserId",
                 table: "Games",
@@ -416,6 +450,11 @@ namespace SteamHub.Api.Migrations
                 name: "IX_GameTag_TagsTagId",
                 table: "GameTag",
                 column: "TagsTagId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ItemTradeDetails_ItemId",
+                table: "ItemTradeDetails",
+                column: "ItemId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_ItemTrades_DestinationUserId",
@@ -460,10 +499,7 @@ namespace SteamHub.Api.Migrations
                 name: "GameTag");
 
             migrationBuilder.DropTable(
-                name: "Items");
-
-            migrationBuilder.DropTable(
-                name: "ItemTrades");
+                name: "ItemTradeDetails");
 
             migrationBuilder.DropTable(
                 name: "StoreTransactions");
@@ -475,10 +511,16 @@ namespace SteamHub.Api.Migrations
                 name: "Tags");
 
             migrationBuilder.DropTable(
-                name: "Games");
+                name: "ItemTrades");
+
+            migrationBuilder.DropTable(
+                name: "Items");
 
             migrationBuilder.DropTable(
                 name: "PointShopItems");
+
+            migrationBuilder.DropTable(
+                name: "Games");
 
             migrationBuilder.DropTable(
                 name: "GameStatus");

--- a/Source/SteamHub.Api/Migrations/DataContextModelSnapshot.cs
+++ b/Source/SteamHub.Api/Migrations/DataContextModelSnapshot.cs
@@ -395,6 +395,38 @@ namespace SteamHub.Api.Migrations
                         });
                 });
 
+            modelBuilder.Entity("SteamHub.Api.Entities.ItemTradeDetail", b =>
+                {
+                    b.Property<int>("TradeId")
+                        .HasColumnType("int");
+
+                    b.Property<int>("ItemId")
+                        .HasColumnType("int");
+
+                    b.Property<bool>("IsSourceUserItem")
+                        .HasColumnType("bit");
+
+                    b.HasKey("TradeId", "ItemId");
+
+                    b.HasIndex("ItemId");
+
+                    b.ToTable("ItemTradeDetails");
+
+                    b.HasData(
+                        new
+                        {
+                            TradeId = 1,
+                            ItemId = 1,
+                            IsSourceUserItem = true
+                        },
+                        new
+                        {
+                            TradeId = 2,
+                            ItemId = 2,
+                            IsSourceUserItem = false
+                        });
+                });
+
             modelBuilder.Entity("SteamHub.Api.Entities.PointShopItem", b =>
                 {
                     b.Property<int>("PointShopItemId")
@@ -897,6 +929,25 @@ namespace SteamHub.Api.Migrations
                     b.Navigation("SourceUser");
                 });
 
+            modelBuilder.Entity("SteamHub.Api.Entities.ItemTradeDetail", b =>
+                {
+                    b.HasOne("SteamHub.Api.Entities.Item", "Item")
+                        .WithMany("ItemTradeDetails")
+                        .HasForeignKey("ItemId")
+                        .OnDelete(DeleteBehavior.Restrict)
+                        .IsRequired();
+
+                    b.HasOne("SteamHub.Api.Entities.ItemTrade", "ItemTrade")
+                        .WithMany("ItemTradeDetails")
+                        .HasForeignKey("TradeId")
+                        .OnDelete(DeleteBehavior.Restrict)
+                        .IsRequired();
+
+                    b.Navigation("Item");
+
+                    b.Navigation("ItemTrade");
+                });
+
             modelBuilder.Entity("SteamHub.Api.Entities.StoreTransaction", b =>
                 {
                     b.HasOne("SteamHub.Api.Entities.Game", "Game")
@@ -949,6 +1000,16 @@ namespace SteamHub.Api.Migrations
             modelBuilder.Entity("SteamHub.Api.Entities.Game", b =>
                 {
                     b.Navigation("StoreTransactions");
+                });
+
+            modelBuilder.Entity("SteamHub.Api.Entities.Item", b =>
+                {
+                    b.Navigation("ItemTradeDetails");
+                });
+
+            modelBuilder.Entity("SteamHub.Api.Entities.ItemTrade", b =>
+                {
+                    b.Navigation("ItemTradeDetails");
                 });
 
             modelBuilder.Entity("SteamHub.Api.Entities.PointShopItem", b =>

--- a/Source/SteamHub.Api/Models/ItemTradeDetails/CreateItemTradeDetailRequest.cs
+++ b/Source/SteamHub.Api/Models/ItemTradeDetails/CreateItemTradeDetailRequest.cs
@@ -1,0 +1,7 @@
+﻿namespace SteamHub.Api.Models.ItemTradeDetails;
+public class CreateItemTradeDetailRequest
+{
+    public int TradeId { get; set; }
+    public int ItemId { get; set; }
+    public bool IsSourceUserItem { get; set; }
+}

--- a/Source/SteamHub.Api/Models/ItemTradeDetails/CreateItemTradeDetailResponse.cs
+++ b/Source/SteamHub.Api/Models/ItemTradeDetails/CreateItemTradeDetailResponse.cs
@@ -1,0 +1,7 @@
+﻿namespace SteamHub.Api.Models.ItemTradeDetails;
+
+public class CreateItemTradeDetailResponse
+{
+    public int TradeId { get; set; }
+    public int ItemId { get; set; }
+}

--- a/Source/SteamHub.Api/Models/ItemTradeDetails/GetItemTradeDetailsResponse.cs
+++ b/Source/SteamHub.Api/Models/ItemTradeDetails/GetItemTradeDetailsResponse.cs
@@ -1,0 +1,5 @@
+﻿namespace SteamHub.Api.Models.ItemTradeDetails;
+public class GetItemTradeDetailsResponse
+{
+    public List<ItemTradeDetailResponse> ItemTradeDetails { get; set; }
+}

--- a/Source/SteamHub.Api/Models/ItemTradeDetails/ItemTradeDetailResponse.cs
+++ b/Source/SteamHub.Api/Models/ItemTradeDetails/ItemTradeDetailResponse.cs
@@ -1,0 +1,7 @@
+﻿namespace SteamHub.Api.Models.ItemTradeDetails;
+public class ItemTradeDetailResponse
+{
+    public int TradeId { get; set; }
+    public int ItemId { get; set; }
+    public bool IsSourceUserItem { get; set; }
+}

--- a/Source/SteamHub.Api/Program.cs
+++ b/Source/SteamHub.Api/Program.cs
@@ -20,6 +20,8 @@ builder.Services.AddScoped<IUserPointShopItemInventoryRepository, UserPointShopI
 builder.Services.AddScoped<IStoreTransactionRepository, StoreTransactionRepository>();
 builder.Services.AddScoped<IItemTradeRepository, ItemTradeRepository>();
 builder.Services.AddScoped<IItemRepository, ItemRepository>();
+builder.Services.AddScoped<IItemTradeDetailRepository, ItemTradeDetailRepository>();
+
 
 builder.Services.AddControllersWithViews()
     .AddJsonOptions(options => { options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter()); });


### PR DESCRIPTION
Feature Name:
ItemTradeDetail Entity, Repository, and Controller

Description:
Adds full CRUD support for tracking items exchanged in a trade, specifying whether the item belongs to the source or destination user. How the feature was implemented:

Created an ItemTradeDetail entity representing a many-to-many relationship between ItemTrades and Items, with a composite primary key.

Added full repository and controller support for:

Creating trade detail records

Fetching all records or by key

Updating trade detail information

Deleting records by composite key

Seeded example data.

Key files affected:
Entities/ItemTradeDetail.cs
Models/ItemTradeDetail/CreateItemTradeDetailRequest.cs Models/ItemTradeDetail/ItemTradeDetailResponse.cs
Models/ItemTradeDetail/GetItemTradeDetailResponse.cs Models/ItemTradeDetail/CreateItemTradeDetailResponse.cs Context/DataContext.cs
Context/Repositories/ItemTradeDetailRepository.cs
Controllers/ItemTradeDetailsController.cs
Program.cs